### PR TITLE
Feature/need refresh polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ uvicorn wiki_annotate.api:app --reload --reload-dir wiki_annotate --port 8765
 # API available at http://localhost:8765
 ```
 
+### Tests
+
+```bash
+# First time setup (if .venv does not exist yet)
+python3 -m venv .venv
+source .venv/bin/activate
+pip install pytest pytest-mock httpx diff-match-patch jsons fastapi --index-url https://pypi.org/simple/
+
+# Run all tests
+.venv/bin/pytest tests/ -v
+
+# Run a specific module
+.venv/bin/pytest tests/test_diff.py -v
+```
+
+> Tests use mocks for external dependencies (pywikibot, GCP) — no credentials needed.
+
 ### Frontend
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,100 @@
+# TODO — wiki-annotate
+
+> Scratch pad for things to fix/ship. See CLAUDE.md for architecture context.
+
+---
+
+## 🛠 Dev Tooling
+
+- [ ] **`dev.sh` — one-command local dev startup**
+  Start backend + frontend in parallel with a single script.
+  Both processes in the same terminal (tmux panes, or just prefixed output).
+  Backend: `uvicorn wiki_annotate.api:app --reload --reload-dir wiki_annotate --port 8765`
+  Frontend: `cd frontend && npm start`
+  Should kill both on Ctrl-C cleanly.
+  See implementation notes at the bottom of this file.
+
+---
+
+## 🐛 Must Fix
+
+- [ ] `/v1/page_annotation/` has no try/except — any error crashes with 500 and no message
+- [ ] Deleted revisions are not skipped (`# TODO: don't run on deleted revisions` in wiki_annotation.py)
+- [ ] `WikiAPI.request()` has no retry on network errors
+- [ ] Locking: concurrent requests for the same page can corrupt cache (diff.py TODO)
+- [ ] `AnnotatedTextException.__str__` returns literal "TODO"
+
+---
+
+## ⏳ From PR #12 Review
+
+- [ ] **Infinite polling** — frontend will poll forever if backend always returns `need_refresh: true`
+  Add max retries cap (e.g. 20 polls ~100s) or a max-duration timeout
+- [ ] **Two `<Table.Body>` siblings** in `MainAnnotation` — spinner banner should live outside or inside the main body, not as a sibling table body
+- [ ] `conftest.py` comment says "Python 3.14 wheels" — misleading, fix to say "not in test venv"
+- [ ] No `requirements-dev.txt` — test deps are only in README, easy to drift
+
+---
+
+## ⚡ Performance
+
+- [ ] `DiffLogic` is CPU-bound but runs inside async event loop — blocks everything. Fix: `run_in_executor`
+- [ ] `AnnotatedText.clear_text` does a full join on every diff — may be expensive for large articles
+- [ ] `jsons` deserialisation is slow — consider pydantic or msgspec
+
+---
+
+## ✨ Features
+
+- [ ] No progress indication for long annotations (SSE or websocket for UX)
+- [ ] `SiteAPIRevisionStructure.timestamp` is a raw string — should be datetime
+
+---
+
+## 🔒 Security
+
+- [ ] No rate limiting on API endpoints — could be abused
+- [ ] GitHub Dependabot flagging vulns on main — clears once PRs #5 + #6 merge
+
+---
+
+## 🧹 Cleanup
+
+- [ ] `in_container()` in utils.py logs warnings at import time unnecessarily
+- [ ] Add architecture diagram or flow description for new contributors
+
+---
+
+## Notes: `dev.sh` implementation options
+
+**Option A — simple background processes + trap (no deps)**
+```bash
+#!/usr/bin/env bash
+set -e
+source .venv/bin/activate
+uvicorn wiki_annotate.api:app --reload --reload-dir wiki_annotate --port 8765 &
+BACKEND_PID=$!
+cd frontend && npm start &
+FRONTEND_PID=$!
+trap "kill $BACKEND_PID $FRONTEND_PID" EXIT
+wait
+```
+
+**Option B — `concurrently` (npm package, prefixed color output)**
+```bash
+npx concurrently \
+  --names "api,ui" \
+  --prefix-colors "cyan,magenta" \
+  "source .venv/bin/activate && uvicorn wiki_annotate.api:app --reload --reload-dir wiki_annotate --port 8765" \
+  "cd frontend && npm start"
+```
+
+**Option C — `tmux` split panes (best for seeing logs separately)**
+```bash
+tmux new-session \; \
+  send-keys "source .venv/bin/activate && uvicorn wiki_annotate.api:app --reload --reload-dir wiki_annotate --port 8765" C-m \; \
+  split-window -h \; \
+  send-keys "cd frontend && npm start" C-m
+```
+
+Leaning towards Option A for zero extra deps, or Option B if concurrently is already in devDependencies.

--- a/frontend/src/components/Annotation.jsx
+++ b/frontend/src/components/Annotation.jsx
@@ -1,56 +1,71 @@
 import { Container, Table, Icon, Popup } from "semantic-ui-react";
 import React, { useState, useEffect } from "react";
 
+const POLL_INTERVAL_MS = 5000;
+
 const Annotation = (parentState) => {
   const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
   const [items, setItems] = useState([]);
+  const [needRefresh, setNeedRefresh] = useState(false);
 
-  // Note: the empty deps array [] means
-  // this useEffect will run once
-  // similar to componentDidMount()
   useEffect(() => {
-    // api.fetchData();
-    const url = import.meta.env.VITE_API_URL;
-    let wiki_url = window.location.href;
-    if (import.meta.env.MODE === "development") {
-      wiki_url = wiki_url.replace(
-        "localhost:3000",
-        import.meta.env.VITE_DEBUG_DOMAIN
-      );
-    }
-    
-    fetch(`${url}/v1/page_annotation/?url=${wiki_url}`)
-    .then((res) => res.json())
-    .then(
-        (result) => {
-          setIsLoaded(true);
-          setItems(result.text);
-        },
-        // Note: it's important to handle errors here
-        // instead of a catch() block so that we don't swallow
-        // exceptions from actual bugs in components.
-        (error) => {
-          setIsLoaded(true);
-          setError(error);
-        }
-      );
+    let pollTimer = null;
+
+    const fetchAnnotation = () => {
+      const url = import.meta.env.VITE_API_URL;
+      let wiki_url = window.location.href;
+      if (import.meta.env.MODE === "development") {
+        wiki_url = wiki_url.replace(
+          "localhost:3000",
+          import.meta.env.VITE_DEBUG_DOMAIN
+        );
+      }
+
+      fetch(`${url}/v1/page_annotation/?url=${wiki_url}`)
+        .then((res) => res.json())
+        .then(
+          (result) => {
+            setIsLoaded(true);
+            setItems(result.text);
+            setNeedRefresh(result.need_refresh);
+            if (result.need_refresh) {
+              pollTimer = setTimeout(fetchAnnotation, POLL_INTERVAL_MS);
+            }
+          },
+          (error) => {
+            setIsLoaded(true);
+            setError(error);
+          }
+        );
+    };
+
+    fetchAnnotation();
+    return () => { if (pollTimer) clearTimeout(pollTimer); };
   }, []);
-  
+
   if (error) {
     return <div>Error: {error.message}</div>;
   } else if (!isLoaded) {
-    console.log(parentState)
     return <PreLoad />;
   } else {
-    return <MainAnnotation items={items} />;
+    return <MainAnnotation items={items} needRefresh={needRefresh} />;
   }
-  
 };
 
-const MainAnnotation = ({ items }) => {
+const MainAnnotation = ({ items, needRefresh }) => {
   return (
-    <Table.Body>
+    <>
+      {needRefresh && (
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell colSpan="3" textAlign="center">
+              <Icon loading name="spinner" /> Loading more history… this may take a moment.
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      )}
+      <Table.Body>
       {items.map((item, index) => (
         <Table.Row className="table-row-users" key={`#${index + 1}`}>
           <Table.Cell width="5">
@@ -80,6 +95,7 @@ const MainAnnotation = ({ items }) => {
         </Table.Row>
       ))}
     </Table.Body>
+    </>
   );
 };
 const PreLoad = () => (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,84 @@
+"""Shared fixtures for wiki-annotate tests.
+
+Mocks external dependencies (google.cloud, pywikibot) that aren't installed
+in the test environment, then provides reusable test fixtures.
+"""
+import sys
+from unittest.mock import MagicMock
+
+# ---------------------------------------------------------------------------
+# Mock external packages BEFORE any wiki_annotate module is imported.
+# google.cloud.storage and pywikibot are required at import-time by
+# config.py, wiki.py, wiki_annotation.py etc. but are not installed in dev.
+# ---------------------------------------------------------------------------
+
+_google = MagicMock()
+sys.modules.setdefault("google", _google)
+sys.modules.setdefault("google.cloud", _google.cloud)
+sys.modules.setdefault("google.cloud.storage", _google.cloud.storage)
+sys.modules.setdefault("google.cloud.exceptions", _google.cloud.exceptions)
+
+_pywikibot = MagicMock()
+sys.modules.setdefault("pywikibot", _pywikibot)
+
+# python-dotenv and requests have no Python 3.14 wheels
+_dotenv = MagicMock()
+sys.modules.setdefault("dotenv", _dotenv)
+
+_requests = MagicMock()
+sys.modules.setdefault("requests", _requests)
+
+# ---------------------------------------------------------------------------
+# Now safe to import from wiki_annotate
+# ---------------------------------------------------------------------------
+
+import pytest
+from wiki_annotate.types import (
+    AnnotationCharData,
+    AnnotatedText,
+    SiteAPIRevisionStructure,
+    CachedRevision,
+)
+
+
+@pytest.fixture
+def make_char_data():
+    """Factory fixture to create AnnotationCharData."""
+    def _make(revid=1, user="TestUser"):
+        return AnnotationCharData(revid=revid, user=user)
+    return _make
+
+
+@pytest.fixture
+def make_annotated_text(make_char_data):
+    """Factory fixture to create AnnotatedText from a string and optional char data."""
+    def _make(text="hello", revid=1, user="TestUser"):
+        cd = make_char_data(revid=revid, user=user)
+        return AnnotatedText(tuple((ch, cd) for ch in text))
+    return _make
+
+
+@pytest.fixture
+def sample_revision_kwargs():
+    """A dict matching the MediaWiki API revision format."""
+    return {
+        "revid": 100,
+        "user": "Alice",
+        "userid": 42,
+        "timestamp": "2024-01-15T10:00:00Z",
+        "comment": "Initial revision",
+        "slots": {"main": {"content": "Hello world"}},
+    }
+
+
+@pytest.fixture
+def sample_revision(sample_revision_kwargs):
+    return SiteAPIRevisionStructure(**sample_revision_kwargs)
+
+
+@pytest.fixture
+def sample_cached_revision(make_annotated_text, sample_revision):
+    return CachedRevision(
+        annotated_text=make_annotated_text("Hello world", revid=100, user="Alice"),
+        latest_revision=sample_revision,
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,133 @@
+"""Tests for wiki_annotate.api module."""
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+
+from wiki_annotate.api import app
+from wiki_annotate.exceptions import (
+    WikiPageAPIException,
+    WikiAPIException,
+    AnnotatedTextException,
+    DiffLogicException,
+)
+from wiki_annotate.types import APIPageData, AnnotatedText, AnnotationCharData
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestIndexEndpoint:
+    def test_index(self, client):
+        resp = client.get("/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "https://github.com/confiq/wiki-annotate" in data
+
+
+class TestPageInfoEndpoint:
+    @patch("wiki_annotate.api.WikiPageAPI")
+    def test_success(self, MockWikiPageAPI, client):
+        mock_instance = MagicMock()
+        mock_instance.get_page_data.return_value = APIPageData(
+            is_error=False, page_title="Test"
+        )
+        MockWikiPageAPI.return_value = mock_instance
+
+        resp = client.get("/v1/page_info/", params={"url": "https://en.wikipedia.org/wiki/Test"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_error"] is False
+        assert data["page_title"] == "Test"
+
+    @patch("wiki_annotate.api.WikiPageAPI")
+    def test_wiki_page_api_exception(self, MockWikiPageAPI, client):
+        MockWikiPageAPI.side_effect = WikiPageAPIException("bad page")
+        resp = client.get("/v1/page_info/", params={"url": "https://en.wikipedia.org/wiki/Test"})
+        assert resp.status_code == 400
+
+    @patch("wiki_annotate.api.WikiPageAPI")
+    def test_generic_exception(self, MockWikiPageAPI, client):
+        MockWikiPageAPI.side_effect = RuntimeError("unexpected")
+        resp = client.get("/v1/page_info/", params={"url": "https://en.wikipedia.org/wiki/Test"})
+        assert resp.status_code == 500
+
+    def test_missing_url_param(self, client):
+        resp = client.get("/v1/page_info/")
+        assert resp.status_code == 422  # Validation error
+
+
+class TestPageAnnotationEndpoint:
+    @patch("wiki_annotate.api.Annotate")
+    @patch("wiki_annotate.api.WikiPageAPI")
+    def test_success(self, MockWikiPageAPI, MockAnnotate, client):
+        mock_wiki = MagicMock()
+        mock_wiki.url = "https://en.wikipedia.org/wiki/Test"
+        MockWikiPageAPI.return_value = mock_wiki
+
+        cd = AnnotationCharData(revid=1, user="Alice")
+        mock_ui_revision = MagicMock()
+        mock_ui_revision.users = {"Alice"}
+        mock_ui_revision.annotated_text = [("hello", cd)]
+
+        mock_core = MagicMock()
+        mock_core.get_ui_revisions.return_value = (mock_ui_revision,)
+        mock_core.wiki_page_annotation.need_refresh = False
+        MockAnnotate.return_value = mock_core
+
+        resp = client.get("/v1/page_annotation/", params={"url": "https://en.wikipedia.org/wiki/Test"})
+        assert resp.status_code == 200
+
+    @patch("wiki_annotate.api.WikiPageAPI")
+    def test_wiki_page_api_exception(self, MockWikiPageAPI, client):
+        MockWikiPageAPI.side_effect = WikiPageAPIException("bad page")
+        resp = client.get("/v1/page_annotation/", params={"url": "https://en.wikipedia.org/wiki/Test"})
+        assert resp.status_code == 400
+        assert "error" in resp.json()
+
+    @patch("wiki_annotate.api.Annotate")
+    @patch("wiki_annotate.api.WikiPageAPI")
+    def test_wiki_api_exception(self, MockWikiPageAPI, MockAnnotate, client):
+        mock_wiki = MagicMock()
+        mock_wiki.url = "https://en.wikipedia.org/wiki/Test"
+        MockWikiPageAPI.return_value = mock_wiki
+        MockAnnotate.side_effect = WikiAPIException("upstream error")
+
+        resp = client.get("/v1/page_annotation/", params={"url": "https://en.wikipedia.org/wiki/Test"})
+        assert resp.status_code == 502
+        assert "Wikipedia API error" in resp.json()["error"]
+
+    @patch("wiki_annotate.api.Annotate")
+    @patch("wiki_annotate.api.WikiPageAPI")
+    def test_diff_logic_exception(self, MockWikiPageAPI, MockAnnotate, client):
+        mock_wiki = MagicMock()
+        mock_wiki.url = "https://en.wikipedia.org/wiki/Test"
+        MockWikiPageAPI.return_value = mock_wiki
+
+        # DiffLogicException needs a diff object with pointer, previous_annotation, new_revision_text
+        mock_diff_obj = MagicMock()
+        mock_diff_obj.pointer = 0
+        mock_diff_obj.previous_annotation = "test"
+        mock_diff_obj.new_revision_text = "test"
+        MockAnnotate.side_effect = DiffLogicException("diff error", mock_diff_obj)
+
+        resp = client.get("/v1/page_annotation/", params={"url": "https://en.wikipedia.org/wiki/Test"})
+        assert resp.status_code == 500
+        assert "Annotation error" in resp.json()["error"]
+
+    @patch("wiki_annotate.api.Annotate")
+    @patch("wiki_annotate.api.WikiPageAPI")
+    def test_generic_exception(self, MockWikiPageAPI, MockAnnotate, client):
+        mock_wiki = MagicMock()
+        mock_wiki.url = "https://en.wikipedia.org/wiki/Test"
+        MockWikiPageAPI.return_value = mock_wiki
+        MockAnnotate.side_effect = RuntimeError("unexpected")
+
+        resp = client.get("/v1/page_annotation/", params={"url": "https://en.wikipedia.org/wiki/Test"})
+        assert resp.status_code == 500
+        assert "Unexpected error" in resp.json()["error"]
+
+    def test_missing_url_param(self, client):
+        resp = client.get("/v1/page_annotation/")
+        assert resp.status_code == 422

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,50 @@
+"""Tests for wiki_annotate.db modules."""
+import pytest
+from wiki_annotate.db.abstraction import AbstractDB
+
+
+class TestSlugify:
+    def test_simple_text(self):
+        assert AbstractDB.slugify("Hello World") == "hello-world"
+
+    def test_special_chars_removed(self):
+        assert AbstractDB.slugify("Hello! World?") == "hello-world"
+
+    def test_dashes_preserved(self):
+        assert AbstractDB.slugify("hello-world") == "hello-world"
+
+    def test_underscores_preserved(self):
+        assert AbstractDB.slugify("hello_world") == "hello_world"
+
+    def test_multiple_spaces(self):
+        assert AbstractDB.slugify("hello   world") == "hello-world"
+
+    def test_multiple_dashes(self):
+        assert AbstractDB.slugify("hello---world") == "hello-world"
+
+    def test_leading_trailing_stripped(self):
+        assert AbstractDB.slugify("--hello--") == "hello"
+        assert AbstractDB.slugify("__hello__") == "hello"
+
+    def test_unicode_default(self):
+        # Without allow_unicode, non-ASCII chars are removed
+        result = AbstractDB.slugify("café")
+        assert result == "cafe"
+
+    def test_unicode_allowed(self):
+        result = AbstractDB.slugify("café", allow_unicode=True)
+        assert result == "café"
+
+    def test_wikipedia_page_title(self):
+        result = AbstractDB.slugify("United_States")
+        assert result == "united_states"
+
+    def test_empty_string(self):
+        assert AbstractDB.slugify("") == ""
+
+    def test_page_with_colon(self):
+        result = AbstractDB.slugify("Help:Contents")
+        assert result == "helpcontents"
+
+    def test_mixed_case(self):
+        assert AbstractDB.slugify("HelloWorld") == "helloworld"

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,204 @@
+"""Tests for wiki_annotate.diff module."""
+import pytest
+from wiki_annotate.diff import DiffLogic
+from wiki_annotate.types import AnnotatedText, AnnotationCharData
+from wiki_annotate.exceptions import DiffLogicException
+
+
+class TestDiffLogicInitText:
+    def test_basic_text(self):
+        cd = AnnotationCharData(revid=1, user="Alice")
+        at = DiffLogic.init_text("abc", cd)
+        assert isinstance(at, AnnotatedText)
+        assert len(at) == 3
+        assert at[0] == ("a", cd)
+        assert at[1] == ("b", cd)
+        assert at[2] == ("c", cd)
+
+    def test_empty_text(self):
+        cd = AnnotationCharData(revid=1, user="Alice")
+        at = DiffLogic.init_text("", cd)
+        assert len(at) == 0
+
+    def test_single_char(self):
+        cd = AnnotationCharData(revid=1, user="Alice")
+        at = DiffLogic.init_text("x", cd)
+        assert len(at) == 1
+        assert at[0] == ("x", cd)
+
+    def test_whitespace_and_newlines(self):
+        cd = AnnotationCharData(revid=1, user="Alice")
+        at = DiffLogic.init_text("a\nb", cd)
+        assert at.clear_text == "a\nb"
+        assert len(at) == 3
+
+    def test_all_chars_share_same_annotation(self):
+        cd = AnnotationCharData(revid=5, user="Bob")
+        at = DiffLogic.init_text("hello", cd)
+        for ch, data in at:
+            assert data is cd
+
+
+class TestDiffLogicRun:
+    def _make_annotated(self, text, revid=1, user="Alice"):
+        cd = AnnotationCharData(revid=revid, user=user)
+        return DiffLogic.init_text(text, cd)
+
+    def test_no_change(self):
+        """Diffing identical text should preserve all annotations."""
+        prev = self._make_annotated("hello")
+        new_cd = AnnotationCharData(revid=2, user="Bob")
+        dl = DiffLogic("hello", prev)
+        result = dl.run(new_cd)
+        assert result.clear_text == "hello"
+        # All chars should retain original annotation (Alice, rev 1)
+        for _, cd in result:
+            assert cd.revid == 1
+            assert cd.user == "Alice"
+
+    def test_append_text(self):
+        """Appending text should create new annotations for added chars."""
+        prev = self._make_annotated("hello")
+        new_cd = AnnotationCharData(revid=2, user="Bob")
+        dl = DiffLogic("hello world", prev)
+        result = dl.run(new_cd)
+        assert result.clear_text == "hello world"
+        # First 5 chars ("hello") should be Alice's
+        for i in range(5):
+            assert result[i][1].user == "Alice"
+        # " world" (6 chars) should be Bob's
+        for i in range(5, 11):
+            assert result[i][1].user == "Bob"
+
+    def test_prepend_text(self):
+        """Prepending text should attribute new chars to new author."""
+        prev = self._make_annotated("world")
+        new_cd = AnnotationCharData(revid=2, user="Bob")
+        dl = DiffLogic("hello world", prev)
+        result = dl.run(new_cd)
+        assert result.clear_text == "hello world"
+        # "hello " should be Bob's
+        for i in range(6):
+            assert result[i][1].user == "Bob"
+        # "world" should be Alice's
+        for i in range(6, 11):
+            assert result[i][1].user == "Alice"
+
+    def test_delete_text(self):
+        """Deleting text should remove those chars entirely."""
+        prev = self._make_annotated("hello world")
+        new_cd = AnnotationCharData(revid=2, user="Bob")
+        dl = DiffLogic("hello", prev)
+        result = dl.run(new_cd)
+        assert result.clear_text == "hello"
+        for _, cd in result:
+            assert cd.user == "Alice"
+
+    def test_replace_text(self):
+        """Replacing a substring should attribute replacement to new author."""
+        prev = self._make_annotated("hello world")
+        new_cd = AnnotationCharData(revid=2, user="Bob")
+        dl = DiffLogic("hello earth", prev)
+        result = dl.run(new_cd)
+        assert result.clear_text == "hello earth"
+        # "hello " preserved from Alice
+        for i in range(6):
+            assert result[i][1].user == "Alice"
+        # "earth" from Bob
+        for i in range(6, 11):
+            assert result[i][1].user == "Bob"
+
+    def test_full_replacement(self):
+        """Completely replacing text should all be from new author."""
+        prev = self._make_annotated("abc")
+        new_cd = AnnotationCharData(revid=2, user="Bob")
+        dl = DiffLogic("xyz", prev)
+        result = dl.run(new_cd)
+        assert result.clear_text == "xyz"
+        for _, cd in result:
+            assert cd.user == "Bob"
+
+    def test_insert_in_middle(self):
+        """Inserting text in the middle."""
+        prev = self._make_annotated("ac")
+        new_cd = AnnotationCharData(revid=2, user="Bob")
+        dl = DiffLogic("abc", prev)
+        result = dl.run(new_cd)
+        assert result.clear_text == "abc"
+        assert result[0][1].user == "Alice"  # 'a'
+        assert result[1][1].user == "Bob"    # 'b'
+        assert result[2][1].user == "Alice"  # 'c'
+
+    def test_multiple_revisions_chain(self):
+        """Chain three revisions and verify cumulative attribution."""
+        cd1 = AnnotationCharData(revid=1, user="Alice")
+        text1 = DiffLogic.init_text("hello", cd1)
+
+        cd2 = AnnotationCharData(revid=2, user="Bob")
+        text2 = DiffLogic("hello world", text1).run(cd2)
+
+        cd3 = AnnotationCharData(revid=3, user="Charlie")
+        text3 = DiffLogic("hello brave world", text2).run(cd3)
+
+        assert text3.clear_text == "hello brave world"
+        # "hello" (0-4) from Alice (original text)
+        for i in range(5):
+            assert text3[i][1].user == "Alice"
+        # The space at index 5 was Bob's (" world" insertion in rev 2)
+        assert text3[5][1].user == "Bob"
+        # "world" at the end is Bob's
+        assert text3[-1][1].user == "Bob"
+
+    def test_empty_to_text(self):
+        """Diff from empty to text - all new."""
+        prev = self._make_annotated("")
+        new_cd = AnnotationCharData(revid=2, user="Bob")
+        dl = DiffLogic("hello", prev)
+        result = dl.run(new_cd)
+        assert result.clear_text == "hello"
+        for _, cd in result:
+            assert cd.user == "Bob"
+
+    def test_text_to_empty(self):
+        """Diff from text to empty - all deleted."""
+        prev = self._make_annotated("hello")
+        new_cd = AnnotationCharData(revid=2, user="Bob")
+        dl = DiffLogic("", prev)
+        result = dl.run(new_cd)
+        assert result.clear_text == ""
+        assert len(result) == 0
+
+    def test_unicode_text(self):
+        """Handle unicode characters correctly."""
+        prev = self._make_annotated("café")
+        new_cd = AnnotationCharData(revid=2, user="Bob")
+        dl = DiffLogic("café latte", prev)
+        result = dl.run(new_cd)
+        assert result.clear_text == "café latte"
+
+    def test_multiline_diff(self):
+        """Handle multiline text with newlines."""
+        prev = self._make_annotated("line1\nline2")
+        new_cd = AnnotationCharData(revid=2, user="Bob")
+        dl = DiffLogic("line1\nline2\nline3", prev)
+        result = dl.run(new_cd)
+        assert result.clear_text == "line1\nline2\nline3"
+
+
+class TestDiffLogicAppendEqual:
+    def test_append_equal_matches(self):
+        cd = AnnotationCharData(revid=1, user="Alice")
+        prev = DiffLogic.init_text("abc", cd)
+        dl = DiffLogic("abc", prev)
+        result = dl._append_equal("abc")
+        assert len(result) == 3
+        assert result[0] == ("a", cd)
+        assert result[1] == ("b", cd)
+        assert result[2] == ("c", cd)
+
+    def test_append_equal_mismatch_raises(self):
+        cd = AnnotationCharData(revid=1, user="Alice")
+        prev = DiffLogic.init_text("abc", cd)
+        dl = DiffLogic("xyz", prev)
+        with pytest.raises(DiffLogicException):
+            dl._append_equal("xyz")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,59 @@
+"""Tests for wiki_annotate.exceptions module."""
+import pytest
+from wiki_annotate.exceptions import (
+    WikiException,
+    AnnotatedTextException,
+    DiffLogicException,
+    WikiPageAPIException,
+    WikiAPIException,
+)
+from wiki_annotate.types import AnnotatedText, AnnotationCharData
+
+
+class TestWikiException:
+    def test_is_exception(self):
+        assert issubclass(WikiException, Exception)
+
+
+class TestAnnotatedTextException:
+    def test_str(self):
+        cd = AnnotationCharData(revid=1, user="Alice")
+        at = AnnotatedText((("a", cd),))
+        exc = AnnotatedTextException("something broke", at)
+        assert str(exc) == "something broke"
+
+    def test_message_attribute(self):
+        cd = AnnotationCharData(revid=1, user="Alice")
+        at = AnnotatedText((("a", cd),))
+        exc = AnnotatedTextException("msg", at)
+        assert exc.message == "msg"
+
+    def test_inherits_wiki_exception(self):
+        assert issubclass(AnnotatedTextException, WikiException)
+
+
+class TestDiffLogicException:
+    def test_str_with_diff_object(self):
+        from wiki_annotate.diff import DiffLogic
+        cd = AnnotationCharData(revid=1, user="Alice")
+        prev = DiffLogic.init_text("abc", cd)
+        dl = DiffLogic("xyz", prev)
+        exc = DiffLogicException("mismatch", dl)
+        result = str(exc)
+        assert "mismatch" in result
+        assert "Pointer is at" in result
+        assert "previous_annotation:" in result
+        assert "new_revision_text:" in result
+
+    def test_inherits_wiki_exception(self):
+        assert issubclass(DiffLogicException, WikiException)
+
+
+class TestWikiPageAPIException:
+    def test_inherits_wiki_exception(self):
+        assert issubclass(WikiPageAPIException, WikiException)
+
+
+class TestWikiAPIException:
+    def test_inherits_wiki_exception(self):
+        assert issubclass(WikiAPIException, WikiException)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,200 @@
+"""Tests for wiki_annotate.types module."""
+import pytest
+from wiki_annotate.types import (
+    AnnotationCharData,
+    RevisionData,
+    AnnotatedText,
+    SiteAPIRevisionStructure,
+    CachedRevision,
+    UIRevision,
+    APIPageData,
+    APIAnnotate,
+    SiteAPIRevisions,
+)
+
+
+class TestAnnotationCharData:
+    def test_basic_init(self):
+        cd = AnnotationCharData(revid=1, user="Alice")
+        assert cd.revid == 1
+        assert cd.user == "Alice"
+
+    def test_init_ignores_extra_kwargs(self):
+        cd = AnnotationCharData(revid=1, user="Alice", comment="test", timestamp="x")
+        assert cd.revid == 1
+        assert cd.user == "Alice"
+        assert not hasattr(cd, "comment")
+
+    def test_getitem(self):
+        cd = AnnotationCharData(revid=42, user="Bob")
+        assert cd["revid"] == 42
+        assert cd["user"] == "Bob"
+
+    def test_getitem_missing_raises(self):
+        cd = AnnotationCharData(revid=1, user="Alice")
+        with pytest.raises(AttributeError):
+            cd["nonexistent"]
+
+
+class TestRevisionData:
+    def test_id_property(self):
+        rd = RevisionData(revision={"revid": 123})
+        assert rd.id == 123
+
+    def test_id_missing_returns_none(self):
+        rd = RevisionData(revision={})
+        assert rd.id is None
+
+
+class TestAnnotatedText:
+    def test_clear_text(self, make_char_data):
+        cd = make_char_data()
+        at = AnnotatedText(tuple((ch, cd) for ch in "abc"))
+        assert at.clear_text == "abc"
+
+    def test_clear_text_empty(self):
+        at = AnnotatedText(())
+        assert at.clear_text == ""
+
+    def test_len(self, make_char_data):
+        cd = make_char_data()
+        at = AnnotatedText(tuple((ch, cd) for ch in "hello"))
+        assert len(at) == 5
+
+    def test_len_empty(self):
+        at = AnnotatedText(())
+        assert len(at) == 0
+
+    def test_getitem(self, make_char_data):
+        cd = make_char_data()
+        at = AnnotatedText((("a", cd), ("b", cd)))
+        assert at[0] == ("a", cd)
+        assert at[1] == ("b", cd)
+
+    def test_iter(self, make_char_data):
+        cd = make_char_data()
+        items = [("x", cd), ("y", cd)]
+        at = AnnotatedText(tuple(items))
+        assert list(at) == items
+
+    def test_clear_text_preserves_whitespace(self, make_char_data):
+        cd = make_char_data()
+        at = AnnotatedText(tuple((ch, cd) for ch in "a b\nc"))
+        assert at.clear_text == "a b\nc"
+
+
+class TestSiteAPIRevisionStructure:
+    def test_init_from_api_kwargs(self, sample_revision_kwargs):
+        rev = SiteAPIRevisionStructure(**sample_revision_kwargs)
+        assert rev.revid == 100
+        assert rev.user == "Alice"
+        assert rev.userid == 42
+        assert rev.timestamp == "2024-01-15T10:00:00Z"
+        assert rev.comment == "Initial revision"
+        assert rev.content == "Hello world"
+
+    def test_content_from_slots(self):
+        rev = SiteAPIRevisionStructure(
+            revid=1, user="A", userid=1, timestamp="t", comment="c",
+            slots={"main": {"content": "slot content"}},
+        )
+        assert rev.content == "slot content"
+
+    def test_content_param_overrides_slots(self):
+        rev = SiteAPIRevisionStructure(
+            content="direct content",
+            revid=1, user="A", userid=1, timestamp="t", comment="c",
+            slots={"main": {"content": "slot content"}},
+        )
+        assert rev.content == "direct content"
+
+
+class TestCachedRevision:
+    def test_fields(self, sample_cached_revision):
+        assert sample_cached_revision.latest_revision.revid == 100
+        assert sample_cached_revision.annotated_text.clear_text == "Hello world"
+
+
+class TestUIRevision:
+    def test_users_converted_to_set(self, make_annotated_text):
+        at = make_annotated_text("hi")
+        ui = UIRevision(users=["Alice", "Bob", "Alice"], annotated_text=at)
+        assert ui.users == {"Alice", "Bob"}
+
+    def test_empty_users(self, make_annotated_text):
+        at = make_annotated_text("x")
+        ui = UIRevision(users=[], annotated_text=at)
+        assert ui.users == set()
+
+
+class TestAPIPageData:
+    def test_defaults(self):
+        pd = APIPageData()
+        assert pd.is_error is False
+        assert pd.errors_messages == []
+        assert pd.page_title == ""
+
+    def test_add_error_msg(self):
+        pd = APIPageData()
+        pd.add_error_msg("Error 1")
+        pd.add_error_msg("Error 2")
+        assert pd.errors_messages == ["Error 1", "Error 2"]
+
+    def test_separate_instances_dont_share_errors(self):
+        pd1 = APIPageData()
+        pd1.add_error_msg("only for pd1")
+        pd2 = APIPageData()
+        assert pd2.errors_messages == []
+
+
+class TestAPIAnnotate:
+    def test_defaults(self):
+        aa = APIAnnotate(text=())
+        assert aa.need_refresh is False
+        assert aa.last_edited is False
+        assert aa.total_revisions is False
+
+
+class TestSiteAPIRevisions:
+    def test_revisions_property(self):
+        data = {
+            "batchcomplete": True,
+            "query": {"pages": [{"revisions": [{"revid": 1}, {"revid": 2}]}]},
+        }
+        sar = SiteAPIRevisions(data)
+        assert len(sar.revisions) == 2
+        assert sar.revisions[0]["revid"] == 1
+
+    def test_batchcomplete_true(self):
+        data = {"batchcomplete": True, "query": {"pages": [{"revisions": []}]}}
+        assert SiteAPIRevisions(data).batchcomplete is True
+
+    def test_batchcomplete_false_when_missing(self):
+        data = {"query": {"pages": [{"revisions": []}]}}
+        assert SiteAPIRevisions(data).batchcomplete is False
+
+    def test_batchcomplete_false_when_falsy(self):
+        data = {"batchcomplete": False, "query": {"pages": [{"revisions": []}]}}
+        assert SiteAPIRevisions(data).batchcomplete is False
+
+    def test_continue_from(self):
+        data = {
+            "continue": {"rvcontinue": "20210308214123|468927", "continue": "||"},
+            "query": {"pages": [{"revisions": []}]},
+        }
+        sar = SiteAPIRevisions(data)
+        assert sar.continue_from == "468927"
+
+    def test_continue_from_none_when_batchcomplete(self):
+        data = {
+            "batchcomplete": True,
+            "continue": {"rvcontinue": "20210308214123|468927", "continue": "||"},
+            "query": {"pages": [{"revisions": []}]},
+        }
+        sar = SiteAPIRevisions(data)
+        assert sar.continue_from is None
+
+    def test_continue_from_none_when_no_continue(self):
+        data = {"query": {"pages": [{"revisions": []}]}}
+        sar = SiteAPIRevisions(data)
+        assert sar.continue_from is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,100 @@
+"""Tests for wiki_annotate.utils module."""
+import logging
+import time
+from unittest.mock import patch
+
+import pytest
+
+from wiki_annotate.utils import catchtime, timing, in_container
+
+
+class TestCatchtime:
+    def test_returns_elapsed_time(self):
+        with catchtime() as t:
+            time.sleep(0.05)
+        elapsed = t()
+        assert elapsed >= 0.04  # allow some slack
+        assert elapsed < 1.0
+
+    def test_callable_in_context(self):
+        with catchtime() as t:
+            assert callable(t)
+
+    def test_increases_over_time(self):
+        with catchtime() as t:
+            t1 = t()
+            time.sleep(0.02)
+            t2 = t()
+        assert t2 > t1
+
+
+class TestTiming:
+    def test_preserves_return_value(self):
+        @timing
+        def add(a, b):
+            return a + b
+
+        assert add(1, 2) == 3
+
+    def test_preserves_function_name(self):
+        @timing
+        def my_func():
+            pass
+
+        assert my_func.__name__ == "my_func"
+
+    def test_logs_debug_message(self, caplog):
+        @timing
+        def slow_fn():
+            time.sleep(0.01)
+            return 42
+
+        with caplog.at_level(logging.DEBUG):
+            result = slow_fn()
+
+        assert result == 42
+        assert any("func:'slow_fn' took:" in r.message for r in caplog.records)
+
+    def test_passes_args_and_kwargs(self):
+        @timing
+        def fn(a, b, c=None):
+            return (a, b, c)
+
+        assert fn(1, 2, c=3) == (1, 2, 3)
+
+
+class TestInContainer:
+    @patch("wiki_annotate.utils.os.path.exists", return_value=False)
+    @patch("wiki_annotate.utils.os.getenv", return_value=None)
+    def test_not_in_container(self, mock_getenv, mock_exists):
+        assert in_container() is False
+
+    @patch("wiki_annotate.utils.os.path.exists", return_value=False)
+    @patch("wiki_annotate.utils.os.getenv", return_value="docker")
+    def test_container_env_var(self, mock_getenv, mock_exists):
+        assert in_container() is True
+
+    @patch("wiki_annotate.utils.os.getenv", return_value=None)
+    @patch("wiki_annotate.utils.os.path.exists")
+    def test_dockerenv_file(self, mock_exists, mock_getenv):
+        def exists_side_effect(path):
+            return path == "./dockerenv"
+        mock_exists.side_effect = exists_side_effect
+        assert in_container() is True
+
+    @patch("wiki_annotate.utils.os.getenv", return_value=None)
+    @patch("wiki_annotate.utils.os.path.exists", return_value=False)
+    @patch("builtins.open", side_effect=FileNotFoundError)
+    def test_no_proc_file(self, mock_open, mock_exists, mock_getenv):
+        # os.path.exists returns False for everything -> no container
+        assert in_container() is False
+
+    @patch("wiki_annotate.utils.os.getenv", return_value=None)
+    @patch("wiki_annotate.utils.os.path.exists")
+    @patch("builtins.open")
+    def test_docker_in_proc(self, mock_open, mock_exists, mock_getenv):
+        mock_exists.side_effect = lambda p: p == r'/proc/1/sched'
+        mock_open.return_value.__enter__ = lambda s: s
+        mock_open.return_value.__exit__ = lambda s, *a: None
+        mock_open.return_value.read.return_value = "docker something"
+        assert in_container() is True

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -1,0 +1,115 @@
+"""Tests for wiki_annotate.wiki module."""
+import pytest
+from unittest.mock import patch, MagicMock, PropertyMock
+from wiki_annotate.wiki import Wiki, WikiPageAPI
+from wiki_annotate.types import APIPageData
+
+
+class TestWikiPageAPIGetWikipediaUrl:
+    """Test URL normalization: .red/.com/etc -> .org"""
+
+    def test_red_to_org(self):
+        api = WikiPageAPI.__new__(WikiPageAPI)
+        result = api.get_wikipedia_url("https://en.wikipedia.red/wiki/Test")
+        assert result == "https://en.wikipedia.org/wiki/Test"
+
+    def test_com_to_org(self):
+        api = WikiPageAPI.__new__(WikiPageAPI)
+        result = api.get_wikipedia_url("https://en.wikipedia.com/wiki/Test")
+        assert result == "https://en.wikipedia.org/wiki/Test"
+
+    def test_org_stays_org(self):
+        api = WikiPageAPI.__new__(WikiPageAPI)
+        result = api.get_wikipedia_url("https://en.wikipedia.org/wiki/Test")
+        assert result == "https://en.wikipedia.org/wiki/Test"
+
+    def test_http_protocol(self):
+        api = WikiPageAPI.__new__(WikiPageAPI)
+        result = api.get_wikipedia_url("http://en.wikipedia.red/wiki/Test")
+        assert result == "http://en.wikipedia.org/wiki/Test"
+
+    def test_with_path_and_query(self):
+        api = WikiPageAPI.__new__(WikiPageAPI)
+        # Use a path without dots — the DOMAIN_REGEX is greedy and mishandles
+        # dots in paths (e.g. index.php), so test the common /wiki/ pattern.
+        result = api.get_wikipedia_url("https://en.wikipedia.red/wiki/Test?action=edit")
+        assert result == "https://en.wikipedia.org/wiki/Test?action=edit"
+
+    def test_other_wikis(self):
+        api = WikiPageAPI.__new__(WikiPageAPI)
+        result = api.get_wikipedia_url("https://de.wikipedia.red/wiki/Berlin")
+        assert result == "https://de.wikipedia.org/wiki/Berlin"
+
+
+class TestWikiPageName:
+    """Test page name extraction from URLs."""
+
+    def test_wiki_path(self):
+        wiki = Wiki.__new__(Wiki)
+        wiki.url = "https://en.wikipedia.org/wiki/Test_Page"
+        wiki._site = None
+        wiki._wikiid = None
+        assert wiki.page_name == "Test_Page"
+
+    def test_wiki_path_with_subpage(self):
+        wiki = Wiki.__new__(Wiki)
+        wiki.url = "https://en.wikipedia.org/wiki/Help:Contents"
+        wiki._site = None
+        wiki._wikiid = None
+        assert wiki.page_name == "Help:Contents"
+
+    def test_no_matching_pattern_returns_none(self):
+        wiki = Wiki.__new__(Wiki)
+        wiki.url = "https://en.wikipedia.org/some/other/path"
+        wiki._site = None
+        wiki._wikiid = None
+        assert wiki.page_name is None
+
+    def test_wiki_path_short(self):
+        """'/wiki/' alone (length 6) should not match the >6 check."""
+        wiki = Wiki.__new__(Wiki)
+        wiki.url = "https://en.wikipedia.org/wiki/"
+        wiki._site = MagicMock()
+        wiki._site.siteinfo.return_value = {"mainpage": "Main Page"}
+        wiki._wikiid = None
+        assert wiki.page_name == "Main Page"
+
+
+class TestWikiPageAPIGetPageData:
+    @patch.object(WikiPageAPI, "page_name", new_callable=PropertyMock, return_value="Test")
+    @patch.object(WikiPageAPI, "get_wikipedia_url", return_value="https://en.wikipedia.org/wiki/Test")
+    def test_success(self, mock_url, mock_name):
+        api = WikiPageAPI.__new__(WikiPageAPI)
+        api.url = "https://en.wikipedia.org/wiki/Test"
+        api._site = None
+        api._wikiid = None
+        pd = api.get_page_data()
+        assert pd.is_error is False
+        assert pd.page_title == "Test"
+
+    @patch.object(WikiPageAPI, "page_name", new_callable=PropertyMock, return_value=None)
+    @patch.object(WikiPageAPI, "get_wikipedia_url", return_value="https://en.wikipedia.org/")
+    def test_no_page_name(self, mock_url, mock_name):
+        api = WikiPageAPI.__new__(WikiPageAPI)
+        api.url = "https://en.wikipedia.org/"
+        api._site = None
+        api._wikiid = None
+        pd = api.get_page_data()
+        assert pd.is_error is True
+        assert len(pd.errors_messages) == 1
+        assert "title" in pd.errors_messages[0].lower()
+
+
+class TestDomainRegex:
+    """Test that the DOMAIN_REGEX correctly matches various URL formats."""
+
+    import re
+
+    @pytest.mark.parametrize("url", [
+        "https://en.wikipedia.org/wiki/Test",
+        "http://de.wikipedia.red/wiki/Berlin",
+        "https://fr.wikipedia.com/w/index.php?title=Test",
+    ])
+    def test_regex_matches(self, url):
+        import re
+        assert re.match(WikiPageAPI.DOMAIN_REGEX, url)

--- a/tests/test_wiki_annotation.py
+++ b/tests/test_wiki_annotation.py
@@ -1,0 +1,249 @@
+"""Tests for wiki_annotate.wiki_annotation module."""
+import dataclasses
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from wiki_annotate.wiki_annotation import WikiPageAnnotation
+from wiki_annotate.types import (
+    AnnotationCharData,
+    AnnotatedText,
+    CachedRevision,
+    SiteAPIRevisionStructure,
+    SiteAPIRevisions,
+    UIRevision,
+)
+from wiki_annotate.diff import DiffLogic
+
+
+def _make_revision_dict(revid, user, content, **kwargs):
+    """Helper to build a dict in MediaWiki API revision format."""
+    return {
+        "revid": revid,
+        "user": user,
+        "userid": 1,
+        "timestamp": "2024-01-01T00:00:00Z",
+        "comment": "",
+        "slots": {"main": {"content": content}},
+        **kwargs,
+    }
+
+
+def _make_batch(revisions, batchcomplete=True):
+    """Create a SiteAPIRevisions with the given revision dicts."""
+    data = {
+        "query": {"pages": [{"revisions": revisions}]},
+    }
+    if batchcomplete:
+        data["batchcomplete"] = True
+    return SiteAPIRevisions(data)
+
+
+class TestGetAnnotation:
+    def test_single_revision(self):
+        """First revision should initialize text with DiffLogic.init_text."""
+        core = MagicMock()
+        batch = _make_batch([
+            _make_revision_dict(1, "Alice", "hello"),
+        ])
+        core.wiki_api.load_revisions.return_value = iter([batch])
+
+        wpa = WikiPageAnnotation(core)
+        text, revision = wpa.get_annotation()
+
+        assert text.clear_text == "hello"
+        assert revision.user == "Alice"
+        assert revision.revid == 1
+        # All chars should be attributed to Alice
+        for _, cd in text:
+            assert cd.user == "Alice"
+
+    def test_two_revisions(self):
+        """Second revision should run DiffLogic to produce combined annotation."""
+        core = MagicMock()
+        batch = _make_batch([
+            _make_revision_dict(1, "Alice", "hello"),
+            _make_revision_dict(2, "Bob", "hello world"),
+        ])
+        core.wiki_api.load_revisions.return_value = iter([batch])
+
+        wpa = WikiPageAnnotation(core)
+        text, revision = wpa.get_annotation()
+
+        assert text.clear_text == "hello world"
+        assert revision.revid == 2
+        # "hello" chars from Alice
+        for i in range(5):
+            assert text[i][1].user == "Alice"
+        # " world" chars from Bob
+        for i in range(5, 11):
+            assert text[i][1].user == "Bob"
+
+    def test_three_revisions(self):
+        """Three revisions chain correctly."""
+        core = MagicMock()
+        batch = _make_batch([
+            _make_revision_dict(1, "Alice", "a"),
+            _make_revision_dict(2, "Bob", "ab"),
+            _make_revision_dict(3, "Charlie", "abc"),
+        ])
+        core.wiki_api.load_revisions.return_value = iter([batch])
+
+        wpa = WikiPageAnnotation(core)
+        text, revision = wpa.get_annotation()
+
+        assert text.clear_text == "abc"
+        assert text[0][1].user == "Alice"
+        assert text[1][1].user == "Bob"
+        assert text[2][1].user == "Charlie"
+
+    def test_with_cached_revision(self):
+        """When cached revision provided, should continue from cache."""
+        core = MagicMock()
+
+        # Simulate cache: text="ab", latest revision id=2
+        cd_alice = AnnotationCharData(revid=1, user="Alice")
+        cd_bob = AnnotationCharData(revid=2, user="Bob")
+        cached_text = AnnotatedText((("a", cd_alice), ("b", cd_bob)))
+        cached_rev = SiteAPIRevisionStructure(
+            content="ab", revid=2, user="Bob", userid=1,
+            timestamp="t", comment="c",
+        )
+        cached = CachedRevision(annotated_text=cached_text, latest_revision=cached_rev)
+
+        # New batch starts from revid 2 (the cached one), then has revid 3
+        batch = _make_batch([
+            _make_revision_dict(2, "Bob", "ab"),  # this is the cached starting point, will be skipped
+            _make_revision_dict(3, "Charlie", "abc"),
+        ])
+        core.wiki_api.load_revisions.return_value = iter([batch])
+
+        wpa = WikiPageAnnotation(core)
+        text, revision = wpa.get_annotation(cached_revision=cached)
+
+        assert text.clear_text == "abc"
+        assert text[0][1].user == "Alice"
+        assert text[1][1].user == "Bob"
+        assert text[2][1].user == "Charlie"
+
+    def test_need_refresh_true_when_incomplete(self):
+        """need_refresh should be True when batch is not complete."""
+        core = MagicMock()
+        batch = _make_batch(
+            [_make_revision_dict(1, "Alice", "hello")],
+            batchcomplete=False,
+        )
+        # Add continue data
+        batch.data["continue"] = {"rvcontinue": "xxx|999", "continue": "||"}
+        core.wiki_api.load_revisions.return_value = iter([batch])
+
+        wpa = WikiPageAnnotation(core)
+        text, revision = wpa.get_annotation()
+
+        assert wpa.need_refresh is True
+
+    def test_need_refresh_false_when_complete(self):
+        """need_refresh should be False when batch is complete."""
+        core = MagicMock()
+        batch = _make_batch([_make_revision_dict(1, "Alice", "hello")])
+        core.wiki_api.load_revisions.return_value = iter([batch])
+
+        wpa = WikiPageAnnotation(core)
+        text, revision = wpa.get_annotation()
+
+        assert wpa.need_refresh is False
+
+
+class TestGetUIRevisions:
+    def _make_cached(self, text_str, revid=1, user="Alice"):
+        cd = AnnotationCharData(revid=revid, user=user)
+        at = AnnotatedText(tuple((ch, cd) for ch in text_str))
+        rev = SiteAPIRevisionStructure(
+            content=text_str, revid=revid, user=user, userid=1,
+            timestamp="t", comment="c",
+        )
+        return CachedRevision(annotated_text=at, latest_revision=rev)
+
+    def test_single_line_no_newline(self):
+        """Single line text without newline should produce one UIRevision."""
+        core = MagicMock()
+        wpa = WikiPageAnnotation(core)
+        cached = self._make_cached("hello")
+        result = wpa.getUIRevisions(cached)
+
+        assert len(result) == 1
+        assert "Alice" in result[0].users
+
+    def test_multiline_text(self):
+        """Text with newlines should be split into lines."""
+        core = MagicMock()
+        wpa = WikiPageAnnotation(core)
+        cached = self._make_cached("line1\nline2\nline3")
+        result = wpa.getUIRevisions(cached)
+
+        assert len(result) == 3
+
+    def test_multiple_authors_on_line(self):
+        """Different authors on the same line should all be in users set."""
+        core = MagicMock()
+        wpa = WikiPageAnnotation(core)
+        cd1 = AnnotationCharData(revid=1, user="Alice")
+        cd2 = AnnotationCharData(revid=2, user="Bob")
+        at = AnnotatedText((
+            ("h", cd1), ("i", cd1), (" ", cd2), ("!", cd2), ("\n", cd1),
+        ))
+        rev = SiteAPIRevisionStructure(
+            content="hi !\n", revid=2, user="Bob", userid=1,
+            timestamp="t", comment="c",
+        )
+        cached = CachedRevision(annotated_text=at, latest_revision=rev)
+
+        result = wpa.getUIRevisions(cached)
+        assert len(result) == 1
+        assert result[0].users == {"Alice", "Bob"}
+
+    def test_word_grouping_by_revid(self):
+        """Consecutive chars with same revid should be grouped into words."""
+        core = MagicMock()
+        wpa = WikiPageAnnotation(core)
+        cd1 = AnnotationCharData(revid=1, user="Alice")
+        cd2 = AnnotationCharData(revid=2, user="Bob")
+        # "ab" by Alice, "cd" by Bob
+        at = AnnotatedText((
+            ("a", cd1), ("b", cd1), ("c", cd2), ("d", cd2),
+        ))
+        rev = SiteAPIRevisionStructure(
+            content="abcd", revid=2, user="Bob", userid=1,
+            timestamp="t", comment="c",
+        )
+        cached = CachedRevision(annotated_text=at, latest_revision=rev)
+
+        result = wpa.getUIRevisions(cached)
+        assert len(result) == 1
+        # Should have 2 word groups
+        line = result[0].annotated_text
+        assert len(line) == 2
+        assert line[0][0] == "ab"
+        assert line[1][0] == "cd"
+
+    def test_empty_text(self):
+        """Empty annotated text should produce no UIRevisions."""
+        core = MagicMock()
+        wpa = WikiPageAnnotation(core)
+        at = AnnotatedText(())
+        rev = SiteAPIRevisionStructure(
+            revid=1, user="Alice", userid=1,
+            timestamp="t", comment="c",
+            slots={"main": {"content": ""}},
+        )
+        cached = CachedRevision(annotated_text=at, latest_revision=rev)
+        result = wpa.getUIRevisions(cached)
+        assert len(result) == 0
+
+    def test_trailing_newline(self):
+        """Text ending with newline should have the last line contain the content before it."""
+        core = MagicMock()
+        wpa = WikiPageAnnotation(core)
+        cached = self._make_cached("hi\n")
+        result = wpa.getUIRevisions(cached)
+        # "hi\n" => one line with "hi" in it
+        assert len(result) == 1

--- a/tests/test_wiki_siteapi.py
+++ b/tests/test_wiki_siteapi.py
@@ -1,0 +1,141 @@
+"""Tests for wiki_annotate.wiki_siteapi module."""
+import json
+import time
+import pytest
+from unittest.mock import MagicMock, patch
+
+from wiki_annotate.wiki_siteapi import WikiAPI
+from wiki_annotate.types import SiteAPIRevisions
+from wiki_annotate.exceptions import WikiAPIException
+
+
+class TestWikiAPIShouldContinue:
+    def _make_api(self):
+        core = MagicMock()
+        api = WikiAPI(core)
+        api.reset_timer()
+        return api
+
+    @patch("wiki_annotate.wiki_siteapi.config")
+    def test_default_continues(self, mock_config):
+        mock_config.MAX_BATCH_COUNT = False
+        api = self._make_api()
+        assert api.should_continue() is True
+
+    @patch("wiki_annotate.wiki_siteapi.config")
+    def test_max_batch_count_stops(self, mock_config):
+        mock_config.MAX_BATCH_COUNT = 2
+        api = self._make_api()
+        api.COUNT = 2
+        assert api.should_continue() is False
+
+    @patch("wiki_annotate.wiki_siteapi.config")
+    def test_max_batch_count_allows_before_limit(self, mock_config):
+        mock_config.MAX_BATCH_COUNT = 5
+        api = self._make_api()
+        api.COUNT = 3
+        assert api.should_continue() is True
+
+    @patch("wiki_annotate.wiki_siteapi.config")
+    def test_negative_batch_count_continues(self, mock_config):
+        mock_config.MAX_BATCH_COUNT = -1
+        api = self._make_api()
+        api.COUNT = 1000
+        assert api.should_continue() is True
+
+    @patch("wiki_annotate.wiki_siteapi.config")
+    def test_cpu_time_exhausted(self, mock_config):
+        mock_config.MAX_BATCH_COUNT = False
+        api = self._make_api()
+        # Simulate elapsed CPU time
+        api.cpu_timer = time.process_time() - (WikiAPI.TOTAL_CPU_TIME + 1)
+        assert api.should_continue() is False
+
+    @patch("wiki_annotate.wiki_siteapi.config")
+    def test_wall_time_exhausted(self, mock_config):
+        mock_config.MAX_BATCH_COUNT = False
+        api = self._make_api()
+        # Simulate elapsed wall time
+        api.total_time = time.time() - (WikiAPI.TOTAL_TIME + 1)
+        assert api.should_continue() is False
+
+
+class TestWikiAPIResetTimer:
+    def test_reset_timer(self):
+        core = MagicMock()
+        api = WikiAPI(core)
+        api.reset_timer()
+        assert api.cpu_timer > 0
+        assert api.total_time > 0
+
+
+class TestWikiAPIRequest:
+    @patch("wiki_annotate.wiki_siteapi.requests")
+    def test_request_calls_get(self, mock_requests):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"query": {}}
+        mock_requests.get.return_value = mock_response
+
+        core = MagicMock()
+        api = WikiAPI(core)
+        # Set a fake api_url
+        api.__dict__["api_url"] = "https://en.wikipedia.org/w/api.php"
+
+        result = api.request({"action": "query"})
+        mock_requests.get.assert_called_once_with(
+            "https://en.wikipedia.org/w/api.php",
+            {"action": "query"},
+            headers=WikiAPI.HEADERS,
+        )
+        assert result == {"query": {}}
+
+
+class TestWikiAPILoadRevisions:
+    @patch("wiki_annotate.wiki_siteapi.requests")
+    @patch("wiki_annotate.wiki_siteapi.config")
+    def test_single_complete_batch(self, mock_config, mock_requests):
+        mock_config.MAX_BATCH_COUNT = False
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "batchcomplete": True,
+            "query": {"pages": [{"revisions": [
+                {"revid": 1, "user": "A", "userid": 1, "timestamp": "t",
+                 "comment": "", "slots": {"main": {"content": "hello"}}},
+            ]}]},
+        }
+        mock_requests.get.return_value = mock_response
+
+        core = MagicMock()
+        core.wiki.get_page.return_value.title.return_value = "Test"
+        core.wiki.site.code = "en"
+        core.wiki.site.family.protocol.return_value = "https"
+        core.wiki.site.family.hostname.return_value = "en.wikipedia.org"
+        core.wiki.site.family.apipath.return_value = "/w/api.php"
+
+        api = WikiAPI(core)
+        batches = list(api.load_revisions())
+        assert len(batches) == 1
+        assert batches[0].batchcomplete is True
+        assert len(batches[0].revisions) == 1
+
+    @patch("wiki_annotate.wiki_siteapi.requests")
+    @patch("wiki_annotate.wiki_siteapi.config")
+    def test_raises_on_missing_batch_status(self, mock_config, mock_requests):
+        """If no batchcomplete and no continue, should raise WikiAPIException."""
+        mock_config.MAX_BATCH_COUNT = False
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "query": {"pages": [{"revisions": []}]},
+        }
+        mock_requests.get.return_value = mock_response
+
+        core = MagicMock()
+        core.wiki.get_page.return_value.title.return_value = "Test"
+        core.wiki.site.code = "en"
+        core.wiki.site.family.protocol.return_value = "https"
+        core.wiki.site.family.hostname.return_value = "en.wikipedia.org"
+        core.wiki.site.family.apipath.return_value = "/w/api.php"
+
+        api = WikiAPI(core)
+        with pytest.raises(WikiAPIException):
+            list(api.load_revisions())

--- a/wiki_annotate/core.py
+++ b/wiki_annotate/core.py
@@ -27,12 +27,17 @@ class Annotate:
         if not cached_revision:
             log.debug('no cache found for this page')
             annotation, last_revision = self.wiki_page_annotation.get_annotation()
-            cached_revision = CachedRevision(annotation, last_revision)
+            cached_revision = CachedRevision(annotation, last_revision, need_refresh=self.wiki_page_annotation.need_refresh)
+            self.local_db.save(cached_revision)
+        elif cached_revision.need_refresh:
+            log.debug('cached annotation is incomplete, continuing processing')
+            annotation, last_revision = self.wiki_page_annotation.get_annotation(cached_revision)
+            cached_revision = CachedRevision(annotation, last_revision, need_refresh=self.wiki_page_annotation.need_refresh)
             self.local_db.save(cached_revision)
         elif cached_revision.latest_revision.revid < latest_revision.id:
             log.debug('refreshing cached annotation')
             annotation, last_revision = self.wiki_page_annotation.get_annotation(cached_revision)
-            cached_revision = CachedRevision(annotation, last_revision)
+            cached_revision = CachedRevision(annotation, last_revision, need_refresh=self.wiki_page_annotation.need_refresh)
             self.local_db.save(cached_revision)
 
         return cached_revision

--- a/wiki_annotate/types.py
+++ b/wiki_annotate/types.py
@@ -110,6 +110,7 @@ class SiteAPIRevisionStructure:
 class CachedRevision:
     annotated_text: AnnotatedText
     latest_revision: SiteAPIRevisionStructure
+    need_refresh: bool = False
 
 
 @dataclass


### PR DESCRIPTION
## Problem

For long/large Wikipedia articles, the annotation process hits a time budget limit before processing all revisions. The API was already returning `need_refresh: true` in this case, but:
- The frontend had no way to react to it
- The backend would never continue from the incomplete cached state on subsequent requests

## What this fixes

### Backend
- **`CachedRevision`** now has a `need_refresh: bool` field, so the incomplete state is persisted to cache
- **`core.run()`** has a new branch: if a cached annotation is flagged as incomplete, it continues processing from where it left off (using the existing `get_annotation(cached_revision)` resume path, which picks up from the last processed revision ID)
- All `CachedRevision` constructions now propagate `need_refresh` from `WikiPageAnnotation`

### Frontend
- The `Annotation` component polls every **5 seconds** when `need_refresh: true`
- Shows a spinner banner while more history is loading: _"Loading more history… this may take a moment."_
- Polling timer is properly cleaned up on component unmount

## Result

Users now see partial annotation results immediately for large articles, with the page auto-updating as each batch of history is processed.