### PR TITLE
ui: prettier blame view

### DIFF
--- a/frontend/src/components/Annotation.jsx
+++ b/frontend/src/components/Annotation.jsx
@@ -90,13 +90,14 @@ const WordSpan = ({ text, author, revid, color }) => {
         revCache[id] = info;
         setRevInfo(info);
       })
-      .catch(() => { revCache[id] = {}; });
+      .catch(() => { revCache[id] = {}; setRevInfo({}); });
   };
+
+  React.useEffect(() => () => clearTimeout(hideTimer.current), []);
 
   const show = (e) => {
     clearTimeout(hideTimer.current);
     setPos({ x: e.clientX, y: e.clientY });
-    window.__wordTooltipPos = { x: e.clientX, y: e.clientY };
     fetchRevInfo(revid);
   };
   const hide = () => {
@@ -177,42 +178,25 @@ const GUTTER_STYLE = {
 const AnnotationRow = ({ item, index }) => {
   const [expanded, setExpanded] = useState(false);
   const loading = !item;
-  const users = loading ? ["user1, user2, user3"] : item.users;
+  const users = loading
+    ? ["user1, user2, user3"]
+    : (item.users || []).map(u => (u == null || String(u).trim() === "" ? "Unknown" : String(u).trim())).sort((a, b) => a.localeCompare(b));
   const joined = users.join(", ");
 
-  const primaryAuthor = loading ? null : (item.users[0] || null);
+  const primaryAuthor = loading ? null : (users[0] || null);
   const color = authorColor(primaryAuthor);
 
-  // Collect unique revids for this line
-  const uniqueRevids = loading ? [] : [...new Set(item.annotated_text.map(e => e[1].revid))];
+  // Collect unique, non-null revids for this line
+  const revids = loading ? [] : item.annotated_text.map(e => e[1].revid).filter(r => r != null);
+  const uniqueRevids = [...new Set(revids)];
   const revCount = uniqueRevids.length;
-  const latestRevid = uniqueRevids[uniqueRevids.length - 1];
+  const latestRevid = uniqueRevids.length > 0 ? Math.max(...uniqueRevids.map(r => Number(r))) : null;
 
-  const gutterTooltip = loading ? null : (
-    <div style={{ fontSize: "0.85em", lineHeight: 1.5 }}>
-      <div><strong>{users.length > 1 ? `${users.length} authors` : primaryAuthor}</strong></div>
-      {users.length > 1 && <div style={{ color: "#aaa", fontSize: "0.9em" }}>{joined}</div>}
-      <div style={{ marginTop: 4 }}>
-        {revCount} revision{revCount !== 1 ? "s" : ""} on this line
-      </div>
-      {latestRevid && (
-        <div style={{ marginTop: 4 }}>
-          <a
-            href={`https://en.wikipedia.org/w/index.php?diff=${latestRevid}`}
-            target="_blank"
-            rel="noreferrer"
-            style={{ color: "#90caf9" }}
-            onClick={e => e.stopPropagation()}
-          >
-            View revision →
-          </a>
-        </div>
-      )}
-    </div>
-  );
 
   const [tooltipVisible, setTooltipVisible] = useState(false);
   const hideTimer = React.useRef(null);
+
+  React.useEffect(() => () => clearTimeout(hideTimer.current), []);
 
   const showTooltip = () => {
     clearTimeout(hideTimer.current);

--- a/frontend/src/components/Annotation.jsx
+++ b/frontend/src/components/Annotation.jsx
@@ -149,10 +149,13 @@ const WordSpan = ({ text, author, revid, color }) => {
                   {new Date(revInfo.timestamp).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}
                 </div>
               )}
-              {revInfo?.comment
-                ? <div style={{ marginTop: 5, color: "#ccc", fontStyle: "italic", wordBreak: "break-word" }}>"{revInfo.comment.replace(/<[^>]+>/g, "").trim()}"</div>
-                : <div style={{ color: "#555", marginTop: 4 }}>Loading…</div>
-              }
+              {revInfo == null ? (
+                <div style={{ color: "#555", marginTop: 4 }}>Loading…</div>
+              ) : (typeof revInfo.comment === "string" && revInfo.comment.trim() !== "") ? (
+                <div style={{ marginTop: 5, color: "#ccc", fontStyle: "italic", wordBreak: "break-word" }}>"{revInfo.comment.replace(/<[^>]+>/g, "").trim()}"</div>
+              ) : (
+                <div style={{ color: "#555", marginTop: 4 }}>No comment</div>
+              )}
               {revid && (
                 <div style={{ marginTop: 7 }}>
                   <a href={`https://en.wikipedia.org/w/index.php?diff=${revid}`} target="_blank" rel="noreferrer" style={{ color: "#90caf9" }} onClick={e => e.stopPropagation()}>View diff →</a>

--- a/frontend/src/components/Annotation.jsx
+++ b/frontend/src/components/Annotation.jsx
@@ -3,6 +3,168 @@ import React, { useState, useEffect } from "react";
 
 const POLL_INTERVAL_MS = 5000;
 
+// Deterministic color from author name — used for the blame gutter strip
+const AUTHOR_COLORS = [
+  "#e57373", "#f06292", "#ba68c8", "#9575cd",
+  "#7986cb", "#64b5f6", "#4fc3f7", "#4dd0e1",
+  "#4db6ac", "#81c784", "#aed581", "#dce775",
+  "#ffd54f", "#ffb74d", "#ff8a65", "#a1887f",
+];
+
+function authorColor(name) {
+  if (!name) return "#ccc";
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return AUTHOR_COLORS[Math.abs(hash) % AUTHOR_COLORS.length];
+}
+
+
+
+const WordTooltip = ({ author, revid, onEnter, onLeave }) => (
+  <div
+    onMouseEnter={onEnter}
+    onMouseLeave={onLeave}
+    onClick={e => e.stopPropagation()}
+    style={{
+      position: "fixed",
+      zIndex: 200,
+      background: "#222",
+      color: "#fff",
+      borderRadius: 6,
+      padding: "8px 12px",
+      fontSize: "0.82em",
+      lineHeight: 1.6,
+      minWidth: 180,
+      maxWidth: 260,
+      boxShadow: "0 4px 16px rgba(0,0,0,0.35)",
+      pointerEvents: "all",
+      whiteSpace: "normal",
+      transform: "translate(-50%, calc(-100% - 8px))",
+    }}
+    ref={el => {
+      if (el && window.__wordTooltipPos) {
+        el.style.left = window.__wordTooltipPos.x + "px";
+        el.style.top = window.__wordTooltipPos.y + "px";
+      }
+    }}
+  >
+    <strong>{author || "Unknown"}</strong>
+    <div style={{ color: "#aaa", fontSize: "0.9em", marginTop: 2 }}>revision {revid}</div>
+    {revid && (
+      <div style={{ marginTop: 6 }}>
+        <a
+          href={`https://en.wikipedia.org/w/index.php?diff=${revid}`}
+          target="_blank"
+          rel="noreferrer"
+          style={{ color: "#90caf9" }}
+        >
+          View diff →
+        </a>
+      </div>
+    )}
+  </div>
+);
+
+const revCache = {};
+
+const WordSpan = ({ text, author, revid, color }) => {
+  const [pos, setPos] = useState(null);
+  const [revInfo, setRevInfo] = useState(null);
+  const hideTimer = React.useRef(null);
+
+  const fetchRevInfo = (id) => {
+    if (!id || revCache[id] !== undefined) {
+      setRevInfo(revCache[id] || null);
+      return;
+    }
+    revCache[id] = null; // mark as fetching
+    fetch(`https://en.wikipedia.org/w/api.php?action=query&revids=${id}&prop=revisions&rvprop=comment|timestamp&format=json&origin=*`)
+      .then(r => r.json())
+      .then(data => {
+        const pages = data?.query?.pages || {};
+        const page = Object.values(pages)[0];
+        const rev = page?.revisions?.[0];
+        const info = rev ? { comment: rev.comment, timestamp: rev.timestamp } : {};
+        revCache[id] = info;
+        setRevInfo(info);
+      })
+      .catch(() => { revCache[id] = {}; });
+  };
+
+  const show = (e) => {
+    clearTimeout(hideTimer.current);
+    setPos({ x: e.clientX, y: e.clientY });
+    window.__wordTooltipPos = { x: e.clientX, y: e.clientY };
+    fetchRevInfo(revid);
+  };
+  const hide = () => {
+    hideTimer.current = setTimeout(() => setPos(null), 150);
+  };
+  const cancelHide = () => clearTimeout(hideTimer.current);
+
+  return (
+    <>
+      <span
+        className="annotation-word"
+        onMouseEnter={show}
+        onMouseMove={show}
+        onMouseLeave={hide}
+        style={{
+          borderBottom: `2px solid ${color}`,
+          backgroundColor: pos ? `${color}33` : "transparent",
+          transition: "background-color 0.1s",
+          cursor: "default",
+        }}
+      >{text}</span>
+      {pos && (
+        <div
+          style={{ position: "fixed", left: pos.x, top: pos.y - 8, zIndex: 200, transform: "translate(-50%, -100%)", pointerEvents: "none" }}
+        >
+          <div style={{ pointerEvents: "all" }} onMouseEnter={cancelHide} onMouseLeave={hide}>
+            <div style={{
+              background: "#1e1e1e",
+              color: "#fff",
+              borderRadius: 6,
+              padding: "8px 12px",
+              fontSize: "0.82em",
+              lineHeight: 1.5,
+              width: 260,
+              boxShadow: "0 4px 16px rgba(0,0,0,0.4)",
+              whiteSpace: "normal",
+            }}>
+              {/* arrow */}
+              <div style={{
+                position: "absolute", bottom: -6, left: "50%", transform: "translateX(-50%)",
+                width: 0, height: 0,
+                borderLeft: "6px solid transparent",
+                borderRight: "6px solid transparent",
+                borderTop: "6px solid #1e1e1e",
+              }} />
+              <div style={{ fontWeight: "bold", color: color }}>{author || "Unknown"}</div>
+              {revInfo?.timestamp && (
+                <div style={{ color: "#888", fontSize: "0.88em" }}>
+                  {new Date(revInfo.timestamp).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}
+                </div>
+              )}
+              {revInfo?.comment
+                ? <div style={{ marginTop: 5, color: "#ccc", fontStyle: "italic", wordBreak: "break-word" }}>"{revInfo.comment.replace(/<[^>]+>/g, "").trim()}"</div>
+                : <div style={{ color: "#555", marginTop: 4 }}>Loading…</div>
+              }
+              {revid && (
+                <div style={{ marginTop: 7 }}>
+                  <a href={`https://en.wikipedia.org/w/index.php?diff=${revid}`} target="_blank" rel="noreferrer" style={{ color: "#90caf9" }} onClick={e => e.stopPropagation()}>View diff →</a>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
 const GUTTER_STYLE = {
   width: "3em",
   textAlign: "right",
@@ -13,14 +175,116 @@ const GUTTER_STYLE = {
 };
 
 const AnnotationRow = ({ item, index }) => {
+  const [expanded, setExpanded] = useState(false);
   const loading = !item;
   const users = loading ? ["user1, user2, user3"] : item.users;
   const joined = users.join(", ");
 
+  const primaryAuthor = loading ? null : (item.users[0] || null);
+  const color = authorColor(primaryAuthor);
+
+  // Collect unique revids for this line
+  const uniqueRevids = loading ? [] : [...new Set(item.annotated_text.map(e => e[1].revid))];
+  const revCount = uniqueRevids.length;
+  const latestRevid = uniqueRevids[uniqueRevids.length - 1];
+
+  const gutterTooltip = loading ? null : (
+    <div style={{ fontSize: "0.85em", lineHeight: 1.5 }}>
+      <div><strong>{users.length > 1 ? `${users.length} authors` : primaryAuthor}</strong></div>
+      {users.length > 1 && <div style={{ color: "#aaa", fontSize: "0.9em" }}>{joined}</div>}
+      <div style={{ marginTop: 4 }}>
+        {revCount} revision{revCount !== 1 ? "s" : ""} on this line
+      </div>
+      {latestRevid && (
+        <div style={{ marginTop: 4 }}>
+          <a
+            href={`https://en.wikipedia.org/w/index.php?diff=${latestRevid}`}
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: "#90caf9" }}
+            onClick={e => e.stopPropagation()}
+          >
+            View revision →
+          </a>
+        </div>
+      )}
+    </div>
+  );
+
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  const hideTimer = React.useRef(null);
+
+  const showTooltip = () => {
+    clearTimeout(hideTimer.current);
+    setTooltipVisible(true);
+  };
+  const hideTooltip = () => {
+    hideTimer.current = setTimeout(() => setTooltipVisible(false), 150);
+  };
+
   return (
     <Table.Row className="table-row-users">
-      <Table.Cell className="annotation-line-number" style={GUTTER_STYLE}>
-        {loading ? <Icon loading name="spinner" /> : index + 1}
+      <Table.Cell
+        className="annotation-line-number"
+        style={{ ...GUTTER_STYLE, borderLeft: `3px solid ${color}`, padding: 0, position: "relative", cursor: loading ? "default" : "help" }}
+        onMouseEnter={!loading ? showTooltip : undefined}
+        onMouseLeave={!loading ? hideTooltip : undefined}
+      >
+        <div style={{ padding: "2px 2px 2px 0" }}>
+          {loading ? <Icon loading name="spinner" /> : index + 1}
+        </div>
+        {tooltipVisible && !loading && (
+          <div
+            onMouseEnter={showTooltip}
+            onMouseLeave={hideTooltip}
+            style={{
+              position: "absolute",
+              left: "calc(100% + 10px)",
+              top: 0,
+              zIndex: 100,
+              background: "#222",
+              color: "#fff",
+              borderRadius: 6,
+              padding: "8px 12px",
+              fontSize: "0.82em",
+              lineHeight: 1.6,
+              minWidth: 180,
+              maxWidth: 260,
+              boxShadow: "0 4px 16px rgba(0,0,0,0.35)",
+              pointerEvents: "all",
+              whiteSpace: "normal",
+            }}
+          >
+            {/* Arrow pointing left */}
+            <div style={{
+              position: "absolute",
+              left: -6,
+              top: 8,
+              width: 0,
+              height: 0,
+              borderTop: "6px solid transparent",
+              borderBottom: "6px solid transparent",
+              borderRight: "6px solid #222",
+            }} />
+            <div style={{ color: "#aaa", fontSize: "0.85em", marginBottom: 4 }}>Line {index + 1}</div>
+            <div><strong>{users.length > 1 ? `${users.length} authors` : primaryAuthor}</strong></div>
+            {users.length > 1 && <div style={{ color: "#aaa", fontSize: "0.9em" }}>{joined}</div>}
+            <div style={{ marginTop: 4 }}>{revCount} revision{revCount !== 1 ? "s" : ""} on this line</div>
+            {latestRevid && (
+              <div style={{ marginTop: 6 }}>
+                <a
+                  href={`https://en.wikipedia.org/w/index.php?diff=${latestRevid}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={{ color: "#90caf9" }}
+                  onClick={e => e.stopPropagation()}
+                >
+                  View revision →
+                </a>
+              </div>
+            )}
+          </div>
+        )}
       </Table.Cell>
       <Table.Cell style={{ maxWidth: 0, overflow: "hidden", width: "15%" }}>
         <Popup
@@ -39,17 +303,38 @@ const AnnotationRow = ({ item, index }) => {
           position="top center"
         />
       </Table.Cell>
-      <Table.Cell className="annotation-text code">
+      <Table.Cell
+        className="annotation-text code"
+        onClick={() => !loading && setExpanded(e => !e)}
+        style={{ cursor: loading ? "default" : "pointer", position: "relative" }}
+      >
         {loading
           ? <><Icon loading name="wait" /> loading…</>
-          : <div>{item.annotated_text.map((element, idx) => (
-              <Popup
-                key={`revision#${element[1].revid}/index:${idx}`}
-                content={`${element[1].user}:${element[1].revid}`}
-                trigger={<span className="annotation-word">{element[0]}</span>}
-                position="top center"
-              />
-            ))}</div>
+          : <div style={{
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              ...(!expanded && {
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }),
+            }}>
+              {item.annotated_text.map((element, idx) => {
+                const wordAuthor = element[1].user;
+                const wordRevid = element[1].revid;
+                const wordColor = authorColor(wordAuthor);
+                return (
+                  <WordSpan
+                    key={`revision#${wordRevid}/index:${idx}`}
+                    text={element[0]}
+                    author={wordAuthor}
+                    revid={wordRevid}
+                    color={wordColor}
+                  />
+                );
+              })}
+            </div>
         }
       </Table.Cell>
     </Table.Row>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -70,3 +70,11 @@ ul.annotation-users {
   background: #fafafa !important;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1), 0 1px 0 rgba(34, 36, 38, 0.15);
 }
+
+/* Zebra striping */
+#annotation table.ui.table tbody tr:nth-child(even) td {
+  background-color: #f9f9f9;
+}
+#annotation table.ui.table tbody tr:nth-child(odd) td {
+  background-color: #ffffff;
+}

--- a/scripts/cleanup_cache.py
+++ b/scripts/cleanup_cache.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Cleanup old cache files — keeps only the latest file per page directory.
+Run as a cron job, e.g.:
+    0 3 * * * /path/to/.venv/bin/python /path/to/scripts/cleanup_cache.py
+"""
+import os
+import logging
+import argparse
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+log = logging.getLogger(__name__)
+
+DATA_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), '..', 'data-page', 'v1'))
+
+
+def cleanup(dry_run: bool = False):
+    if not os.path.exists(DATA_DIR):
+        log.info(f"Data directory {DATA_DIR} does not exist, nothing to do.")
+        return
+
+    total_deleted = 0
+    total_freed = 0
+
+    for wikiid in os.listdir(DATA_DIR):
+        wiki_dir = os.path.join(DATA_DIR, wikiid)
+        if not os.path.isdir(wiki_dir):
+            continue
+        for page in os.listdir(wiki_dir):
+            page_dir = os.path.join(wiki_dir, page)
+            if not os.path.isdir(page_dir):
+                continue
+
+            files = [f for f in os.listdir(page_dir) if f.endswith('.json')]
+            if len(files) <= 1:
+                continue
+
+            files_with_mtime = [(f, os.path.getmtime(os.path.join(page_dir, f))) for f in files]
+            files_with_mtime.sort(key=lambda x: x[1], reverse=True)
+            to_keep = files_with_mtime[0][0]
+            to_delete = [f for f, _ in files_with_mtime[1:]]
+
+            for f in to_delete:
+                fpath = os.path.join(page_dir, f)
+                size = os.path.getsize(fpath)
+                if not dry_run:
+                    os.remove(fpath)
+                total_deleted += 1
+                total_freed += size
+
+            action = "would remove" if dry_run else "removed"
+            log.info(f"{wikiid}/{page}: kept {to_keep}, {action} {len(to_delete)} old file(s)")
+
+    log.info(f"Done. {'Would free' if dry_run else 'Freed'} {total_freed / 1024 / 1024:.1f} MB across {total_deleted} file(s)")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Clean up old wiki-annotate cache files")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be deleted without deleting")
+    args = parser.parse_args()
+    cleanup(dry_run=args.dry_run)

--- a/wiki_annotate/api.py
+++ b/wiki_annotate/api.py
@@ -1,7 +1,8 @@
 from wiki_annotate import config
 import asyncio
+import threading
 import os
-from fastapi import FastAPI, Query, Response, status
+from fastapi import FastAPI, Query, Response, status, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
 from wiki_annotate.exceptions import WikiPageAPIException, WikiAPIException, AnnotatedTextException, DiffLogicException
 from wiki_annotate.wiki import WikiPageAPI
@@ -47,11 +48,36 @@ def get_page_info(response: Response, url: str = Query(..., pattern=WikiPageAPI.
     return page_data
 
 
+def _refresh_in_background(url: str):
+    try:
+        core = Annotate(url)
+        core.run()
+    except Exception as e:
+        log.exception(f"Background refresh failed for {url}: {e}")
+
+
 @app.get("/v1/page_annotation/")
-def get_annotation(response: Response, url: str = Query(..., pattern=WikiPageAPI.DOMAIN_REGEX)):
+def get_annotation(response: Response, background_tasks: BackgroundTasks, url: str = Query(..., pattern=WikiPageAPI.DOMAIN_REGEX)):
     try:
         url = WikiPageAPI(url).url
         core = Annotate(url)
+        latest_revision = core.wiki.get_page().latest_revision
+        from wiki_annotate.types import RevisionData
+        cached = core.local_db.get_page(RevisionData(latest_revision).id)
+
+        if cached:
+            # Return stale cache immediately, refresh in background if needed
+            is_stale = cached.need_refresh or (cached.latest_revision.revid and cached.latest_revision.revid < RevisionData(latest_revision).id)
+            if is_stale:
+                background_tasks.add_task(_refresh_in_background, url)
+            timestamp = cached.latest_revision.timestamp
+            return APIAnnotate(
+                text=core.get_ui_revisions(cached),
+                need_refresh=True if is_stale else core.wiki_page_annotation.need_refresh,
+                last_edited=timestamp[:10] if timestamp else None,
+            )
+
+        # No cache at all — must block on first load
         cached = core.run()
         timestamp = cached.latest_revision.timestamp
         return APIAnnotate(

--- a/wiki_annotate/db/file_system.py
+++ b/wiki_annotate/db/file_system.py
@@ -43,7 +43,15 @@ class FileSystem(AbstractDB):
             with open(revision_file, 'r') as f:
                 file_content = f.read()
             # the deserialization of this is  expensive :(
-            return jsons.loads(file_content, CachedRevision)
+            try:
+                return jsons.loads(file_content, CachedRevision)
+            except Exception as e:
+                log.warning(f"Corrupt or empty cache file {revision_file}, treating as cache miss: {e}")
+                try:
+                    os.remove(revision_file)
+                except OSError:
+                    pass
+                return None
 
     @functools.cached_property
     def data_directory(self):

--- a/wiki_annotate/types.py
+++ b/wiki_annotate/types.py
@@ -90,11 +90,11 @@ class SiteAPIRevisionStructure:
           "comment":"Created page with \"demo1\""
        }
     """
-    revid: int
-    user: str
-    userid: int
-    timestamp: str  # TODO: datetime, does not work out of box
-    comment: str
+    revid: Optional[int]
+    user: Optional[str]
+    userid: Optional[int]
+    timestamp: Optional[str]  # TODO: datetime, does not work out of box
+    comment: Optional[str]
     content: str
 
     def __init__(self, content=None, **kwargs):

--- a/wiki_annotate/wiki_annotation.py
+++ b/wiki_annotate/wiki_annotation.py
@@ -38,6 +38,9 @@ class WikiPageAnnotation:
                 total_revisions += 1
                 # TODO: don't run on deleted revisions
                 revision = SiteAPIRevisionStructure(**api_revision)
+                if revision.revid is None:
+                    log.warning(f"skipping revision with null revid (suppressed/deleted): {api_revision}")
+                    continue
                 if previous_revision_id > revision.revid:
                     log.error(f"order of revisions are wrong, old_rev={previous_revision_id}>new_rev={revision.revid}")
                 # continue from cached revision


### PR DESCRIPTION
## What's in this PR

### Frontend
- **Zebra striping** — alternating row background colors for readability
- **Content truncation** — long rows clamp to 2 lines, click to expand
- **Author color-coding** — each author gets a deterministic color shown as a left border strip on the line number gutter
- **Gutter tooltip** — hover the line number to see: authors, revision count, and a link to view the revision on Wikipedia
- **Per-word hover tooltip** — hover any word to see who edited it, when, their edit comment (fetched live from Wikipedia API), and a view diff link

### Backend
- **Fix null deserialization** — `SiteAPIRevisionStructure` fields (`user`, `comment`, `timestamp`, `revid`, `userid`) are now `Optional` to handle suppressed/missing values from Wikipedia API