### PR TITLE
fix: cap infinite polling, fix AnnotatedTextException bug, clean up conftest comment

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,10 +27,10 @@
 
 ## ⏳ From PR #12 Review
 
-- [ ] **Infinite polling** — frontend will poll forever if backend always returns `need_refresh: true`
-  Add max retries cap (e.g. 20 polls ~100s) or a max-duration timeout
+- [x] **Infinite polling** — frontend will poll forever if backend always returns `need_refresh: true`
+  Added `MAX_POLLS = 24` cap (~2 min). Polling stops and banner clears after limit.
 - [x] **Two `<Table.Body>` siblings** in `MainAnnotation` — spinner banner should live outside or inside the main body, not as a sibling table body
-- [ ] `conftest.py` comment says "Python 3.14 wheels" — misleading, fix to say "not in test venv"
+- [x] `conftest.py` comment says "Python 3.14 wheels" — misleading, fix to say "not in test venv"
 - [ ] No `requirements-dev.txt` — test deps are only in README, easy to drift
 
 ---

--- a/frontend/src/components/Annotation.jsx
+++ b/frontend/src/components/Annotation.jsx
@@ -2,6 +2,7 @@ import { Container, Table, Icon, Popup, Message } from "semantic-ui-react";
 import React, { useState, useEffect } from "react";
 
 const POLL_INTERVAL_MS = 5000;
+const MAX_POLLS = 24; // ~2 minutes of polling before giving up
 
 // Deterministic color from author name — used for the blame gutter strip
 const AUTHOR_COLORS = [
@@ -337,6 +338,7 @@ const Annotation = (parentState) => {
 
   useEffect(() => {
     let pollTimer = null;
+    let pollCount = 0;
 
     const fetchAnnotation = () => {
       const url = import.meta.env.VITE_API_URL;
@@ -360,9 +362,11 @@ const Annotation = (parentState) => {
           (result) => {
             setIsLoaded(true);
             setItems(result.text);
-            setNeedRefresh(result.need_refresh);
             setLastEdited(result.last_edited || null);
-            if (result.need_refresh) {
+            const shouldPoll = result.need_refresh && pollCount < MAX_POLLS;
+            setNeedRefresh(shouldPoll);
+            if (shouldPoll) {
+              pollCount += 1;
               pollTimer = setTimeout(fetchAnnotation, POLL_INTERVAL_MS);
             }
           },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ sys.modules.setdefault("google.cloud.exceptions", _google.cloud.exceptions)
 _pywikibot = MagicMock()
 sys.modules.setdefault("pywikibot", _pywikibot)
 
-# python-dotenv and requests have no Python 3.14 wheels
+# python-dotenv and requests are not installed in the test venv — mock them out
 _dotenv = MagicMock()
 sys.modules.setdefault("dotenv", _dotenv)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -28,6 +28,12 @@ class TestAnnotatedTextException:
         exc = AnnotatedTextException("msg", at)
         assert exc.message == "msg"
 
+    def test_annotated_text_attribute_is_instance(self):
+        cd = AnnotationCharData(revid=1, user="Alice")
+        at = AnnotatedText((("a", cd),))
+        exc = AnnotatedTextException("something broke", at)
+        assert exc.annotated_text is at
+
     def test_inherits_wiki_exception(self):
         assert issubclass(AnnotatedTextException, WikiException)
 

--- a/wiki_annotate/exceptions.py
+++ b/wiki_annotate/exceptions.py
@@ -8,7 +8,7 @@ class WikiException(Exception): pass
 class AnnotatedTextException(WikiException):
     def __init__(self, message, annotated_text: AnnotatedText):
         self.message = message
-        self.annotated_text = AnnotatedText
+        self.annotated_text = annotated_text
 
     def __str__(self):
         return self.message


### PR DESCRIPTION
## What's in here

### 🐛 Bug: `AnnotatedTextException` stored the class, not the instance
```python
# Before (bug — stores the class object itself)
self.annotated_text = AnnotatedText

# After
self.annotated_text = annotated_text
```

### ⏱️ Frontend: infinite polling capped at MAX_POLLS = 24 (~2 min)
If the backend keeps returning `need_refresh: true`, the frontend was polling forever. Now it gives up after 24 polls and clears the loading banner. Closes the TODO from PR #12 review.

### 🧹 conftest.py comment cleanup
The comment "python-dotenv and requests have no Python 3.14 wheels" was misleading — they're mocked because they're not in the test venv, not because of wheel availability.