### PR TITLE
perf: offload DiffLogic and blocking I/O to ThreadPoolExecutor

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,9 @@
 
 ## ⚡ Performance
 
-- [ ] `DiffLogic` is CPU-bound but runs inside async event loop — blocks everything. Fix: `run_in_executor`
+- [x] `DiffLogic` is CPU-bound but runs inside async event loop — blocks everything. Fix: `run_in_executor`
+  Routes are now `async def`; all blocking work (DiffLogic, pywikibot, file I/O) offloaded to a
+  dedicated `ThreadPoolExecutor`. Pool size configurable via `ANNOTATE_WORKERS` env var (default 4).
 - [ ] `AnnotatedText.clear_text` does a full join on every diff — may be expensive for large articles
 - [ ] `jsons` deserialisation is slow — consider pydantic or msgspec
 

--- a/wiki_annotate/api.py
+++ b/wiki_annotate/api.py
@@ -13,10 +13,28 @@ import logging
 
 log = logging.getLogger(__name__)
 
+def _get_max_workers(default: int = 4) -> int:
+    """Safely parse ANNOTATE_WORKERS from the environment.
+
+    Falls back to `default` on missing/invalid values and enforces a minimum of 1.
+    """
+    raw = os.getenv("ANNOTATE_WORKERS")
+    if not raw:
+        return default
+    try:
+        workers = int(raw)
+        if workers < 1:
+            raise ValueError("must be >= 1")
+        return workers
+    except (TypeError, ValueError) as exc:
+        log.warning("Invalid ANNOTATE_WORKERS value %r (%s); falling back to default %d", raw, exc, default)
+        return default
+
+
 # Dedicated thread pool for CPU-bound / blocking work (DiffLogic, pywikibot, file I/O).
 # Using a named pool makes it visible in thread dumps and profilers.
 _executor = ThreadPoolExecutor(
-    max_workers=int(os.getenv("ANNOTATE_WORKERS", "4")),
+    max_workers=_get_max_workers(),
     thread_name_prefix="wiki-annotate",
 )
 

--- a/wiki_annotate/api.py
+++ b/wiki_annotate/api.py
@@ -1,18 +1,33 @@
 from wiki_annotate import config
 import asyncio
-import threading
 import os
+from contextlib import asynccontextmanager
+from concurrent.futures import ThreadPoolExecutor
 from fastapi import FastAPI, Query, Response, status, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
 from wiki_annotate.exceptions import WikiPageAPIException, WikiAPIException, AnnotatedTextException, DiffLogicException
 from wiki_annotate.wiki import WikiPageAPI
 from wiki_annotate.core import Annotate
-from wiki_annotate.types import APIPageData, APIAnnotate
+from wiki_annotate.types import APIPageData, APIAnnotate, RevisionData
 import logging
 
-app = FastAPI()
 log = logging.getLogger(__name__)
 
+# Dedicated thread pool for CPU-bound / blocking work (DiffLogic, pywikibot, file I/O).
+# Using a named pool makes it visible in thread dumps and profilers.
+_executor = ThreadPoolExecutor(
+    max_workers=int(os.getenv("ANNOTATE_WORKERS", "4")),
+    thread_name_prefix="wiki-annotate",
+)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    yield
+    _executor.shutdown(wait=False)
+
+
+app = FastAPI(lifespan=lifespan)
 
 _extra = [o.strip() for o in os.getenv("CORS_ORIGINS", "").split(",") if o.strip()]
 origins = ["http://localhost:3000"] + _extra
@@ -32,11 +47,11 @@ def index():
 
 
 @app.get("/v1/page_info/")
-def get_page_info(response: Response, url: str = Query(..., pattern=WikiPageAPI.DOMAIN_REGEX)):
-
+async def get_page_info(response: Response, url: str = Query(..., pattern=WikiPageAPI.DOMAIN_REGEX)):
+    loop = asyncio.get_running_loop()
     page_data = APIPageData(is_error=True)
     try:
-        page_data = WikiPageAPI(url).get_page_data()
+        page_data = await loop.run_in_executor(_executor, lambda: WikiPageAPI(url).get_page_data())
     except WikiPageAPIException as e:
         log.exception(e)
         page_data.add_error_msg(f'Error: {e}')
@@ -57,31 +72,39 @@ def _refresh_in_background(url: str):
 
 
 @app.get("/v1/page_annotation/")
-def get_annotation(response: Response, background_tasks: BackgroundTasks, url: str = Query(..., pattern=WikiPageAPI.DOMAIN_REGEX)):
+async def get_annotation(response: Response, background_tasks: BackgroundTasks, url: str = Query(..., pattern=WikiPageAPI.DOMAIN_REGEX)):
+    loop = asyncio.get_running_loop()
     try:
         url = WikiPageAPI(url).url
         core = Annotate(url)
-        latest_revision = core.wiki.get_page().latest_revision
-        from wiki_annotate.types import RevisionData
-        cached = core.local_db.get_page(RevisionData(latest_revision).id)
+
+        # Blocking: hits Wikipedia API + local cache — offload to thread pool
+        latest_revision = await loop.run_in_executor(_executor, lambda: core.wiki.get_page().latest_revision)
+        cached = await loop.run_in_executor(_executor, lambda: core.local_db.get_page(RevisionData(latest_revision).id))
 
         if cached:
             # Return stale cache immediately, refresh in background if needed
-            is_stale = cached.need_refresh or (cached.latest_revision.revid and cached.latest_revision.revid < RevisionData(latest_revision).id)
+            is_stale = cached.need_refresh or (
+                cached.latest_revision.revid and
+                cached.latest_revision.revid < RevisionData(latest_revision).id
+            )
             if is_stale:
                 background_tasks.add_task(_refresh_in_background, url)
             timestamp = cached.latest_revision.timestamp
+            # CPU-bound: building UI revision tuples — offload to thread pool
+            ui_revisions = await loop.run_in_executor(_executor, lambda: core.get_ui_revisions(cached))
             return APIAnnotate(
-                text=core.get_ui_revisions(cached),
+                text=ui_revisions,
                 need_refresh=True if is_stale else core.wiki_page_annotation.need_refresh,
                 last_edited=timestamp[:10] if timestamp else None,
             )
 
-        # No cache at all — must block on first load
-        cached = core.run()
+        # No cache at all — block on first annotation run (DiffLogic-heavy)
+        cached = await loop.run_in_executor(_executor, core.run)
         timestamp = cached.latest_revision.timestamp
+        ui_revisions = await loop.run_in_executor(_executor, lambda: core.get_ui_revisions(cached))
         return APIAnnotate(
-            text=core.get_ui_revisions(cached),
+            text=ui_revisions,
             need_refresh=core.wiki_page_annotation.need_refresh,
             last_edited=timestamp[:10] if timestamp else None,
         )


### PR DESCRIPTION
## Problem

`DiffLogic` is CPU-bound (pure Python `diff_match_patch`) and was running inline in sync route handlers. FastAPI does threadpool sync routes automatically, but:
- Event loop is exposed if routes are ever made `async def`
- No control over pool size or thread naming (invisible in profilers/thread dumps)

## Changes

- **Dedicated `ThreadPoolExecutor`** with named threads (`wiki-annotate-N`), configurable via `ANNOTATE_WORKERS` env var (default: 4)
- **Routes converted to `async def`** (`get_page_info`, `get_annotation`)
- **All blocking calls offloaded** via `loop.run_in_executor(_executor, ...)`:
  - `core.wiki.get_page()` — pywikibot I/O
  - `core.local_db.get_page()` — file I/O
  - `core.run()` — the expensive path (DiffLogic + Wikipedia API + cache write)
  - `core.get_ui_revisions()` — CPU-bound tuple building
- **Executor shut down cleanly** via FastAPI `lifespan` context manager

## Result

The event loop is free to handle other requests while annotation work runs in the thread pool. Under concurrent load, multiple pages can be annotated in parallel up to the pool size.