### PR TITLE
perf: cache clear_text to avoid O(n) recompute on every revision diff

### DIFF
--- a/wiki_annotate/diff.py
+++ b/wiki_annotate/diff.py
@@ -17,7 +17,9 @@ class DiffLogic:
 
     @staticmethod
     def init_text(text: str, annotated_char_data: AnnotationCharData) -> AnnotatedText:
-        return AnnotatedText(tuple((letter, annotated_char_data) for letter in text))
+        result = AnnotatedText(tuple((letter, annotated_char_data) for letter in text))
+        result._clear_text = text
+        return result
 
     def run(self, new_annotation: AnnotationCharData) -> AnnotatedText:
         try:
@@ -40,7 +42,9 @@ class DiffLogic:
                 raise NotImplementedError(f"We don't know about DIFF of type '{diff[0]}'")
         merged: Tuple[str, AnnotationCharData] = tuple(i for sub in return_text for i in sub)
         # TODO: should we check if pointer is at the end of file so we double check if Diff is kosher?
-        return AnnotatedText(merged)
+        result = AnnotatedText(merged)
+        result._clear_text = str(self.new_revision_text)
+        return result
 
     def _append_equal(self, text: str):
         return_data = []

--- a/wiki_annotate/types.py
+++ b/wiki_annotate/types.py
@@ -58,15 +58,22 @@ class AnnotatedText:
     @property
     def clear_text(self) -> str:
         """
-        get clear text of Annotation
-        # TODO: run profile and check if this is expensive or not! If yes, send full text within __init__
+        get clear text of Annotation.
+        Cached as a dynamic attribute (_clear_text) to avoid recomputing O(n) zip+join
+        on every revision diff. Set explicitly by DiffLogic after each run so the cost
+        is paid at most once per AnnotatedText lifetime (e.g. on first use after cache load).
         :return: clear text
         """
+        cached = getattr(self, '_clear_text', None)
+        if cached is not None:
+            return cached
         if len(self.text) == 0:
             log.warning('Got length of 0 chars')
             return ''
         l, _ = zip(*self.text)
-        return ''.join(l)
+        result = ''.join(l)
+        self._clear_text = result
+        return result
 
 
 @dataclass


### PR DESCRIPTION
## Problem

`AnnotatedText.clear_text` was called on every single revision during annotation — doing `zip(*self.text)` + `''.join()` each time. For a heavy page like Pelé (~50KB article, ~20K revisions) that's ~1 billion char operations per full annotation run.

The TODO in `clear_text` even flagged this:
```python
# TODO: run profile and check if this is expensive or not! If yes, send full text within __init__
```

## Fix

`DiffLogic` now sets `_clear_text` as a dynamic instance attribute on every `AnnotatedText` it produces:

- `init_text` — sets it directly from the input `text` string (zero cost)
- `run` — sets it from `self.new_revision_text` (already in memory)

The `clear_text` property checks `getattr(self, '_clear_text', None)` first and only falls back to the expensive `zip+join` if missing (e.g. first call after a cache load — once per request, not once per revision).

## No serialization impact

`_clear_text` is not a declared dataclass field, so `jsons` ignores it on save/load. Old cache files remain fully compatible.