### PR TITLE
fix: fall back to previous cache file on corruption instead of cache miss

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,11 @@
 """Tests for wiki_annotate.db modules."""
+import json
+import os
+import time
 import pytest
+import jsons
 from wiki_annotate.db.abstraction import AbstractDB
+from wiki_annotate.db.file_system import FileSystem
 
 
 class TestSlugify:
@@ -48,3 +53,95 @@ class TestSlugify:
 
     def test_mixed_case(self):
         assert AbstractDB.slugify("HelloWorld") == "helloworld"
+
+
+@pytest.fixture
+def fs(tmp_path, monkeypatch):
+    """FileSystem instance pointing at a temp directory."""
+    instance = FileSystem.__new__(FileSystem)
+    monkeypatch.setattr(type(instance), "data_directory",
+                        property(lambda self: str(tmp_path)))
+    return instance
+
+
+def _write_cache(fs, wikiid, page, revision, cached_revision):
+    """Helper: serialise and write a valid cache file."""
+    fs.save_page_data(wikiid, page, cached_revision, revision)
+
+
+def _write_corrupt(fs, wikiid, page, revision):
+    """Helper: write an empty / invalid JSON file to simulate corruption."""
+    slug = AbstractDB.slugify(page)
+    dir_name = os.path.join(fs.data_directory, wikiid, slug)
+    os.makedirs(dir_name, exist_ok=True)
+    with open(os.path.join(dir_name, f"{revision}.json"), "w") as f:
+        f.write("")  # empty → invalid JSON
+
+
+class TestFileSystemGetPageData:
+
+    def test_returns_none_when_no_cache_dir(self, fs):
+        assert fs.get_page_data("en-wikipedia", "nonexistent") is None
+
+    def test_returns_none_when_dir_empty(self, fs, sample_cached_revision):
+        slug = AbstractDB.slugify("pele")
+        os.makedirs(os.path.join(fs.data_directory, "en-wikipedia", slug))
+        assert fs.get_page_data("en-wikipedia", "pele") is None
+
+    def test_returns_valid_cache(self, fs, sample_cached_revision):
+        _write_cache(fs, "en-wikipedia", "pele", 100, sample_cached_revision)
+        result = fs.get_page_data("en-wikipedia", "pele")
+        assert result is not None
+        assert result.latest_revision.revid == sample_cached_revision.latest_revision.revid
+
+    def test_corrupt_latest_falls_back_to_previous(self, fs, sample_cached_revision):
+        # Write a valid older cache, then a corrupt newer one
+        _write_cache(fs, "en-wikipedia", "pele", 100, sample_cached_revision)
+        time.sleep(0.01)  # ensure mtime ordering
+        _write_corrupt(fs, "en-wikipedia", "pele", 200)
+
+        result = fs.get_page_data("en-wikipedia", "pele")
+        assert result is not None
+        assert result.latest_revision.revid == 100
+
+    def test_corrupt_file_is_deleted_after_fallback(self, fs, sample_cached_revision):
+        _write_cache(fs, "en-wikipedia", "pele", 100, sample_cached_revision)
+        time.sleep(0.01)
+        _write_corrupt(fs, "en-wikipedia", "pele", 200)
+
+        slug = AbstractDB.slugify("pele")
+        corrupt_path = os.path.join(fs.data_directory, "en-wikipedia", slug, "200.json")
+        assert os.path.exists(corrupt_path)
+
+        fs.get_page_data("en-wikipedia", "pele")
+        assert not os.path.exists(corrupt_path)
+
+    def test_all_corrupt_returns_none(self, fs):
+        _write_corrupt(fs, "en-wikipedia", "pele", 100)
+        _write_corrupt(fs, "en-wikipedia", "pele", 200)
+        assert fs.get_page_data("en-wikipedia", "pele") is None
+
+    def test_specific_revision_returned_when_requested(self, fs, sample_cached_revision):
+        _write_cache(fs, "en-wikipedia", "pele", 100, sample_cached_revision)
+        result = fs.get_page_data("en-wikipedia", "pele", revision=100)
+        assert result is not None
+        assert result.latest_revision.revid == 100
+
+    def test_specific_revision_missing_falls_back_to_latest(self, fs, sample_cached_revision):
+        # revision=999 doesn't exist — should fall back to latest valid file
+        _write_cache(fs, "en-wikipedia", "pele", 100, sample_cached_revision)
+        result = fs.get_page_data("en-wikipedia", "pele", revision=999)
+        assert result is not None
+        assert result.latest_revision.revid == 100
+
+    def test_multiple_corrupt_falls_back_to_oldest_valid(self, fs, sample_cached_revision):
+        # valid at 100, corrupt at 200 and 300
+        _write_cache(fs, "en-wikipedia", "pele", 100, sample_cached_revision)
+        time.sleep(0.01)
+        _write_corrupt(fs, "en-wikipedia", "pele", 200)
+        time.sleep(0.01)
+        _write_corrupt(fs, "en-wikipedia", "pele", 300)
+
+        result = fs.get_page_data("en-wikipedia", "pele")
+        assert result is not None
+        assert result.latest_revision.revid == 100

--- a/wiki_annotate/db/file_system.py
+++ b/wiki_annotate/db/file_system.py
@@ -28,30 +28,36 @@ class FileSystem(AbstractDB):
     def get_page_data(self, wikiid: str, page: str, revision: int = None) -> Union[None, CachedRevision]:
         page = self.slugify(page)
         dir_name = path.join(self.data_directory, wikiid, page)
-        revision_file = None
-        if path.exists(dir_name):
-            revision_file = path.join(dir_name, f"{revision}.json")
-            revision_file = revision_file if revision and path.exists(revision_file) else None
-            if not revision_file:
-                # need to get latest revision file, this can be very expensive if we have lot of revisions
-                files = os.listdir(dir_name)
-                if files:
-                    # Select by modification time to handle non-monotonic revids
-                    latest_file = max(files, key=lambda f: os.path.getmtime(path.join(dir_name, f)))
-                    revision_file = path.join(dir_name, latest_file)
-        if revision_file:
+        if not path.exists(dir_name):
+            return None
+
+        # If a specific revision was requested and it exists, try that first
+        if revision and path.exists(path.join(dir_name, f"{revision}.json")):
+            candidates = [f"{revision}.json"]
+        else:
+            candidates = []
+
+        # Append all files sorted by mtime descending as fallback candidates
+        files = os.listdir(dir_name)
+        candidates += sorted(files, key=lambda f: os.path.getmtime(path.join(dir_name, f)), reverse=True)
+
+        for filename in candidates:
+            revision_file = path.join(dir_name, filename)
+            if not path.exists(revision_file):
+                continue
             with open(revision_file, 'r') as f:
                 file_content = f.read()
-            # the deserialization of this is  expensive :(
+            # the deserialization of this is expensive :(
             try:
                 return jsons.loads(file_content, CachedRevision)
             except Exception as e:
-                log.warning(f"Corrupt or empty cache file {revision_file}, treating as cache miss: {e}")
+                log.warning(f"Corrupt or empty cache file {revision_file}, falling back to previous: {e}")
                 try:
                     os.remove(revision_file)
                 except OSError:
                     pass
-                return None
+
+        return None
 
     @functools.cached_property
     def data_directory(self):

--- a/wiki_annotate/db/file_system.py
+++ b/wiki_annotate/db/file_system.py
@@ -33,22 +33,25 @@ class FileSystem(AbstractDB):
 
         # If a specific revision was requested and it exists, try that first
         if revision and path.exists(path.join(dir_name, f"{revision}.json")):
-            candidates = [f"{revision}.json"]
+            requested_file = f"{revision}.json"
+            candidates = [requested_file]
         else:
+            requested_file = None
             candidates = []
 
-        # Append all files sorted by mtime descending as fallback candidates
+        # Append all files sorted by mtime descending as fallback candidates,
+        # excluding the requested_file if it was already added above.
         files = os.listdir(dir_name)
+        if requested_file is not None:
+            files = [f for f in files if f != requested_file]
         candidates += sorted(files, key=lambda f: os.path.getmtime(path.join(dir_name, f)), reverse=True)
 
         for filename in candidates:
             revision_file = path.join(dir_name, filename)
-            if not path.exists(revision_file):
-                continue
-            with open(revision_file, 'r') as f:
-                file_content = f.read()
             # the deserialization of this is expensive :(
             try:
+                with open(revision_file, 'r') as f:
+                    file_content = f.read()
                 return jsons.loads(file_content, CachedRevision)
             except Exception as e:
                 log.warning(f"Corrupt or empty cache file {revision_file}, falling back to previous: {e}")


### PR DESCRIPTION
## Problem

When the most recent cache file is corrupt (e.g. interrupted write), `get_page_data` would delete it and return `None`, causing a full cache miss. This reset annotation progress back to revision 1 — for large articles like Pelé this meant losing all accumulated work.

## Fix

Instead of bailing immediately on a corrupt file, iterate through all cache files sorted by mtime descending and try each one. Corrupt files are still deleted, but processing falls back to the next most recent valid file automatically.

Only returns `None` if every file in the directory is corrupt (true cache miss).

## Behaviour change

- Corrupt latest file → falls back to previous valid cache, preserving progress
- Specific revision requested → tried first, then falls back to sorted list
- All files corrupt → returns `None` (same as before)