### PR TITLE
fix: in-memory cache for deserialized CachedRevision to avoid redundant jsons.loads

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -5,6 +5,7 @@ import time
 import pytest
 import jsons
 from wiki_annotate.db.abstraction import AbstractDB
+import wiki_annotate.db.file_system as fs_module
 from wiki_annotate.db.file_system import FileSystem
 
 
@@ -145,3 +146,77 @@ class TestFileSystemGetPageData:
         result = fs.get_page_data("en-wikipedia", "pele")
         assert result is not None
         assert result.latest_revision.revid == 100
+
+
+@pytest.fixture(autouse=True)
+def clear_memory_cache():
+    """Reset the module-level in-memory cache between tests."""
+    fs_module._memory_cache.clear()
+    fs_module._file_locks.clear()
+    yield
+    fs_module._memory_cache.clear()
+    fs_module._file_locks.clear()
+
+
+class TestFileSystemMemoryCache:
+
+    def test_jsons_loads_called_once_for_repeated_reads(self, fs, sample_cached_revision, monkeypatch):
+        """Second call for the same revision must be served from memory — jsons.loads not called again."""
+        _write_cache(fs, "en-wikipedia", "pele", 100, sample_cached_revision)
+
+        call_count = 0
+        original_loads = jsons.loads
+
+        def counting_loads(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return original_loads(*args, **kwargs)
+
+        monkeypatch.setattr(fs_module.jsons, "loads", counting_loads)
+
+        fs.get_page_data("en-wikipedia", "pele")
+        fs.get_page_data("en-wikipedia", "pele")
+
+        assert call_count == 1, f"jsons.loads called {call_count} times; expected 1 (cache should serve second read)"
+
+    def test_cache_result_is_identical_object(self, fs, sample_cached_revision):
+        """Memory cache should return the exact same CachedRevision instance."""
+        _write_cache(fs, "en-wikipedia", "pele", 100, sample_cached_revision)
+
+        result1 = fs.get_page_data("en-wikipedia", "pele")
+        result2 = fs.get_page_data("en-wikipedia", "pele")
+
+        assert result1 is result2
+
+    def test_lru_eviction_respects_max_size(self, fs, sample_cached_revision, monkeypatch):
+        """Cache should not grow beyond _CACHE_MAX_SIZE entries."""
+        monkeypatch.setattr(fs_module, "_CACHE_MAX_SIZE", 3)
+
+        for rev in range(1, 6):
+            _write_cache(fs, "en-wikipedia", f"page{rev}", rev, sample_cached_revision)
+            fs.get_page_data("en-wikipedia", f"page{rev}")
+
+        assert len(fs_module._memory_cache) <= 3
+
+    def test_different_revisions_each_deserialize_once(self, fs, sample_cached_revision, monkeypatch):
+        """Each distinct revision file should be deserialized exactly once."""
+        _write_cache(fs, "en-wikipedia", "pele", 100, sample_cached_revision)
+        _write_cache(fs, "en-wikipedia", "maradona", 200, sample_cached_revision)
+
+        call_count = 0
+        original_loads = jsons.loads
+
+        def counting_loads(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return original_loads(*args, **kwargs)
+
+        monkeypatch.setattr(fs_module.jsons, "loads", counting_loads)
+
+        # Read each twice
+        fs.get_page_data("en-wikipedia", "pele")
+        fs.get_page_data("en-wikipedia", "pele")
+        fs.get_page_data("en-wikipedia", "maradona")
+        fs.get_page_data("en-wikipedia", "maradona")
+
+        assert call_count == 2, f"Expected 2 deserialisations (one per unique file), got {call_count}"

--- a/wiki_annotate/db/file_system.py
+++ b/wiki_annotate/db/file_system.py
@@ -14,6 +14,10 @@ from wiki_annotate.utils import timing
 
 log = logging.getLogger(__name__)
 
+# In-memory cache of deserialized CachedRevision objects, keyed by absolute file path.
+# Filenames are revision-based so a new revision = new key; no explicit invalidation needed.
+_memory_cache: dict[str, CachedRevision] = {}
+
 
 class FileSystem(AbstractDB):
     DATA_VERSION = 'v1'
@@ -82,6 +86,9 @@ class FileSystem(AbstractDB):
         for filename in candidates:
             revision_file = path.join(dir_name, filename)
             # the deserialization of this is expensive :(
+            if revision_file in _memory_cache:
+                log.debug(f"Cache hit (memory) for {revision_file}")
+                return _memory_cache[revision_file]
             try:
                 with open(revision_file, 'r') as f:
                     file_content = f.read()
@@ -91,6 +98,7 @@ class FileSystem(AbstractDB):
                 log.debug(f"Cache deserialised in {duration:.2f}s ({len(file_content)} bytes, {revision_file})")
                 if duration > 0.5:
                     log.info(f"Slow cache deserialisation in {duration:.2f}s ({len(file_content)} bytes, {revision_file})")
+                _memory_cache[revision_file] = result
                 return result
             except Exception as e:
                 log.warning(f"Corrupt or empty cache file {revision_file}, falling back to previous: {e}")

--- a/wiki_annotate/db/file_system.py
+++ b/wiki_annotate/db/file_system.py
@@ -1,7 +1,9 @@
 from wiki_annotate.db.abstraction import AbstractDB
 from wiki_annotate.types import CachedRevision
 from abc import ABC, abstractmethod
+import collections
 import functools
+import threading
 from typing import List, Set, Dict, Tuple, Optional, Union
 from os import path
 import os
@@ -14,9 +16,24 @@ from wiki_annotate.utils import timing
 
 log = logging.getLogger(__name__)
 
-# In-memory cache of deserialized CachedRevision objects, keyed by absolute file path.
+# In-memory LRU cache of deserialized CachedRevision objects, keyed by absolute file path.
 # Filenames are revision-based so a new revision = new key; no explicit invalidation needed.
-_memory_cache: dict[str, CachedRevision] = {}
+# Bounded to _CACHE_MAX_SIZE entries; oldest entries are evicted when full.
+_CACHE_MAX_SIZE = 256
+_memory_cache: collections.OrderedDict[str, CachedRevision] = collections.OrderedDict()
+_memory_cache_lock = threading.Lock()  # guards all _memory_cache operations
+
+# Per-file locks: ensures only one thread deserializes a given file at a time.
+# Other threads that race to the same file will block and then get the cached result.
+_file_locks: dict[str, threading.Lock] = {}
+_file_locks_lock = threading.Lock()  # guards _file_locks dict membership
+
+
+def _get_file_lock(file_path: str) -> threading.Lock:
+    with _file_locks_lock:
+        if file_path not in _file_locks:
+            _file_locks[file_path] = threading.Lock()
+        return _file_locks[file_path]
 
 
 class FileSystem(AbstractDB):
@@ -85,27 +102,48 @@ class FileSystem(AbstractDB):
 
         for filename in candidates:
             revision_file = path.join(dir_name, filename)
-            # the deserialization of this is expensive :(
-            if revision_file in _memory_cache:
-                log.debug(f"Cache hit (memory) for {revision_file}")
-                return _memory_cache[revision_file]
-            try:
-                with open(revision_file, 'r') as f:
-                    file_content = f.read()
-                t0 = time.perf_counter()
-                result = jsons.loads(file_content, CachedRevision)
-                duration = time.perf_counter() - t0
-                log.debug(f"Cache deserialised in {duration:.2f}s ({len(file_content)} bytes, {revision_file})")
-                if duration > 0.5:
-                    log.info(f"Slow cache deserialisation in {duration:.2f}s ({len(file_content)} bytes, {revision_file})")
-                _memory_cache[revision_file] = result
-                return result
-            except Exception as e:
-                log.warning(f"Corrupt or empty cache file {revision_file}, falling back to previous: {e}")
+
+            # Fast path: check cache before acquiring per-file lock.
+            with _memory_cache_lock:
+                if revision_file in _memory_cache:
+                    log.debug(f"Cache hit (memory) for {revision_file}")
+                    _memory_cache.move_to_end(revision_file)
+                    return _memory_cache[revision_file]
+
+            # Slow path: acquire per-file lock so only one thread deserializes.
+            # Other threads racing here will block, then hit the fast-path above.
+            file_lock = _get_file_lock(revision_file)
+            with file_lock:
+                # Re-check: another thread may have populated the cache while we waited.
+                with _memory_cache_lock:
+                    if revision_file in _memory_cache:
+                        log.debug(f"Cache hit (memory, post-lock) for {revision_file}")
+                        _memory_cache.move_to_end(revision_file)
+                        return _memory_cache[revision_file]
+
                 try:
-                    os.remove(revision_file)
-                except OSError:
-                    pass
+                    with open(revision_file, 'r') as f:
+                        file_content = f.read()
+                    t0 = time.perf_counter()
+                    result = jsons.loads(file_content, CachedRevision)
+                    duration = time.perf_counter() - t0
+                    log.debug(f"Cache deserialised in {duration:.2f}s ({len(file_content)} bytes, {revision_file})")
+                    if duration > 0.5:
+                        log.info(f"Slow cache deserialisation in {duration:.2f}s ({len(file_content)} bytes, {revision_file})")
+
+                    with _memory_cache_lock:
+                        _memory_cache[revision_file] = result
+                        _memory_cache.move_to_end(revision_file)
+                        if len(_memory_cache) > _CACHE_MAX_SIZE:
+                            _memory_cache.popitem(last=False)
+
+                    return result
+                except Exception as e:
+                    log.warning(f"Corrupt or empty cache file {revision_file}, falling back to previous: {e}")
+                    try:
+                        os.remove(revision_file)
+                    except OSError:
+                        pass
 
         return None
 


### PR DESCRIPTION
## Problem

Each frontend poll (every 5s) triggers a new HTTP request which deserializes the same cache file from scratch. With the ThreadPoolExecutor running concurrent requests, this results in 5-8 parallel `jsons.loads` calls on the same 10MB JSON file — each taking 25-46 seconds and competing for CPU.

## Fix

Add a module-level `_memory_cache` dict keyed by absolute file path. After the first deserialization, the result is stored in memory. Subsequent requests for the same revision get an instant cache hit and skip `jsons.loads` entirely.

Filenames are revision-based (`<revid>.json`) so a new revision = new key — no explicit invalidation needed.

## Result

- First request for a revision: pays deserialization cost once (~25s for Pelé)
- All subsequent requests: instant memory hit
- Concurrent polls no longer pile up deserializing the same file

## Notes

- `_memory_cache` is an unbounded dict — fine for dev, but should be replaced with an LRU cache for prod (tracked in TODO)